### PR TITLE
Feature/RL1M-51

### DIFF
--- a/ittory-api/build.gradle
+++ b/ittory-api/build.gradle
@@ -27,5 +27,5 @@ dependencies {
 }
 
 tasks.named('test') {
-    dependsOn ':ittory-domain:test', ':ittory-common:test'
+    dependsOn ':ittory-domain:test', ':ittory-common:test', ':ittory-infra:test'
 }

--- a/ittory-api/build.gradle
+++ b/ittory-api/build.gradle
@@ -25,3 +25,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 
 }
+
+tasks.named('test') {
+    dependsOn ':ittory-domain:test', ':ittory-common:test'
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
@@ -1,11 +1,14 @@
 package com.ittory.api.auth.controller;
 
+import com.ittory.api.annotation.AuthMember;
 import com.ittory.api.auth.dto.AuthTokenResponse;
 import com.ittory.api.auth.dto.KaKaoLoginRequest;
 import com.ittory.api.auth.dto.TokenRefreshRequest;
 import com.ittory.api.auth.dto.TokenRefreshResponse;
 import com.ittory.api.auth.usecase.KaKaoLoginUseCase;
+import com.ittory.api.auth.usecase.LogoutUseCase;
 import com.ittory.api.auth.usecase.TokenRefreshUseCase;
+import com.ittory.domain.member.domain.Member;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +27,7 @@ public class AuthController {
 
     private final KaKaoLoginUseCase kaKaoLoginUseCase;
     private final TokenRefreshUseCase tokenRefreshUseCase;
+    private final LogoutUseCase logoutUseCase;
 
     @PostMapping("/login/kakao")
     public ResponseEntity<AuthTokenResponse> loginByKaKao(@Valid @RequestBody KaKaoLoginRequest request) {
@@ -37,6 +41,12 @@ public class AuthController {
         TokenRefreshResponse response = tokenRefreshUseCase.execute(request.getAccessToken(),
                 request.getRefreshToken());
         return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthMember Member member) {
+        logoutUseCase.execute(member);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.ittory.api.auth.usecase.KaKaoLoginUseCase;
 import com.ittory.api.auth.usecase.LogoutUseCase;
 import com.ittory.api.auth.usecase.TokenRefreshUseCase;
 import com.ittory.domain.member.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class AuthController {
     private final TokenRefreshUseCase tokenRefreshUseCase;
     private final LogoutUseCase logoutUseCase;
 
+    @Operation(summary = "카카오 소셜 로그인")
     @PostMapping("/login/kakao")
     public ResponseEntity<AuthTokenResponse> loginByKaKao(@Valid @RequestBody KaKaoLoginRequest request) {
         AuthTokenResponse response = kaKaoLoginUseCase.execute(request.getCode());
@@ -36,6 +38,7 @@ public class AuthController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(summary = "Access Token 갱신")
     @PostMapping("/refresh")
     public ResponseEntity<TokenRefreshResponse> refreshMemberToken(@Valid @RequestBody TokenRefreshRequest request) {
         TokenRefreshResponse response = tokenRefreshUseCase.execute(request.getAccessToken(),
@@ -43,6 +46,7 @@ public class AuthController {
         return ResponseEntity.ok().body(response);
     }
 
+    @Operation(summary = "로그아웃", description = "Authenticated")
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@AuthMember Member member) {
         logoutUseCase.execute(member);

--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.ittory.api.auth.controller;
+
+import com.ittory.api.auth.dto.AuthTokenResponse;
+import com.ittory.api.auth.dto.KaKaoLoginRequest;
+import com.ittory.api.auth.usecase.KaKaoLoginUseCase;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@Slf4j
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final KaKaoLoginUseCase kaKaoLoginUseCase;
+
+    @PostMapping("/login/kakao")
+    public ResponseEntity<AuthTokenResponse> loginByKaKao(@RequestBody KaKaoLoginRequest request) {
+        AuthTokenResponse response = kaKaoLoginUseCase.execute(request.getCode());
+        log.info("Login with {} in {}", response.getAccessToken(), LocalDateTime.now());
+        return ResponseEntity.ok().body(response);
+    }
+
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
@@ -2,7 +2,10 @@ package com.ittory.api.auth.controller;
 
 import com.ittory.api.auth.dto.AuthTokenResponse;
 import com.ittory.api.auth.dto.KaKaoLoginRequest;
+import com.ittory.api.auth.dto.TokenRefreshRequest;
+import com.ittory.api.auth.dto.TokenRefreshResponse;
 import com.ittory.api.auth.usecase.KaKaoLoginUseCase;
+import com.ittory.api.auth.usecase.TokenRefreshUseCase;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,11 +22,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final KaKaoLoginUseCase kaKaoLoginUseCase;
+    private final TokenRefreshUseCase tokenRefreshUseCase;
 
     @PostMapping("/login/kakao")
     public ResponseEntity<AuthTokenResponse> loginByKaKao(@RequestBody KaKaoLoginRequest request) {
         AuthTokenResponse response = kaKaoLoginUseCase.execute(request.getCode());
         log.info("Login with {} in {}", response.getAccessToken(), LocalDateTime.now());
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenRefreshResponse> refreshMemberToken(@RequestBody TokenRefreshRequest request) {
+        TokenRefreshResponse response = tokenRefreshUseCase.execute(request.getAccessToken(),
+                request.getRefreshToken());
         return ResponseEntity.ok().body(response);
     }
 

--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.ittory.api.auth.dto.TokenRefreshRequest;
 import com.ittory.api.auth.dto.TokenRefreshResponse;
 import com.ittory.api.auth.usecase.KaKaoLoginUseCase;
 import com.ittory.api.auth.usecase.TokenRefreshUseCase;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,14 +26,14 @@ public class AuthController {
     private final TokenRefreshUseCase tokenRefreshUseCase;
 
     @PostMapping("/login/kakao")
-    public ResponseEntity<AuthTokenResponse> loginByKaKao(@RequestBody KaKaoLoginRequest request) {
+    public ResponseEntity<AuthTokenResponse> loginByKaKao(@Valid @RequestBody KaKaoLoginRequest request) {
         AuthTokenResponse response = kaKaoLoginUseCase.execute(request.getCode());
         log.info("Login with {} in {}", response.getAccessToken(), LocalDateTime.now());
         return ResponseEntity.ok().body(response);
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<TokenRefreshResponse> refreshMemberToken(@RequestBody TokenRefreshRequest request) {
+    public ResponseEntity<TokenRefreshResponse> refreshMemberToken(@Valid @RequestBody TokenRefreshRequest request) {
         TokenRefreshResponse response = tokenRefreshUseCase.execute(request.getAccessToken(),
                 request.getRefreshToken());
         return ResponseEntity.ok().body(response);

--- a/ittory-api/src/main/java/com/ittory/api/auth/dto/AuthTokenResponse.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/dto/AuthTokenResponse.java
@@ -1,0 +1,20 @@
+package com.ittory.api.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthTokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+
+    public static AuthTokenResponse of(String accessToken, String refreshToken) {
+        return new AuthTokenResponse(accessToken, refreshToken);
+    }
+
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/dto/KaKaoLoginRequest.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/dto/KaKaoLoginRequest.java
@@ -1,5 +1,6 @@
 package com.ittory.api.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class KaKaoLoginRequest {
 
+    @Schema(description = "카카오 인가 코드")
     @NotNull
     private String code;
 

--- a/ittory-api/src/main/java/com/ittory/api/auth/dto/KaKaoLoginRequest.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/dto/KaKaoLoginRequest.java
@@ -1,0 +1,14 @@
+package com.ittory.api.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class KaKaoLoginRequest {
+    private String code;
+
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/dto/KaKaoLoginRequest.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/dto/KaKaoLoginRequest.java
@@ -1,5 +1,6 @@
 package com.ittory.api.auth.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class KaKaoLoginRequest {
 
+    @NotNull
     private String code;
 
 }

--- a/ittory-api/src/main/java/com/ittory/api/auth/dto/TokenRefreshRequest.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/dto/TokenRefreshRequest.java
@@ -1,15 +1,14 @@
 package com.ittory.api.auth.dto;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-public class KaKaoLoginRequest {
+public class TokenRefreshRequest {
 
-    private String code;
+    private String accessToken;
+    private String refreshToken;
 
 }

--- a/ittory-api/src/main/java/com/ittory/api/auth/dto/TokenRefreshRequest.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/dto/TokenRefreshRequest.java
@@ -1,5 +1,6 @@
 package com.ittory.api.auth.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TokenRefreshRequest {
 
+    @NotNull
     private String accessToken;
+    @NotNull
     private String refreshToken;
 
 }

--- a/ittory-api/src/main/java/com/ittory/api/auth/dto/TokenRefreshResponse.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/dto/TokenRefreshResponse.java
@@ -1,0 +1,19 @@
+package com.ittory.api.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenRefreshResponse {
+
+    private String accessToken;
+
+    public static TokenRefreshResponse of(String accessToken) {
+        return new TokenRefreshResponse(accessToken);
+    }
+
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/exception/AuthErrorCode.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/exception/AuthErrorCode.java
@@ -1,0 +1,20 @@
+package com.ittory.api.auth.exception;
+
+import static com.ittory.common.exception.ErrorStatus.BAD_REQUEST;
+import static com.ittory.common.exception.ErrorStatus.FORBIDDEN;
+
+import com.ittory.common.exception.ErrorStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode {
+
+    NO_REFRESH_TOKEN(FORBIDDEN, "5000", "로그아웃된 사용자입니다."),
+    REFRESH_TOKEN_NOT_MATCH(BAD_REQUEST, "5001", "Refresh Token이 일치하지 않습니다.");
+
+    private final ErrorStatus status;
+    private final String code;
+    private final String message;
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/exception/AuthException.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/exception/AuthException.java
@@ -1,0 +1,31 @@
+package com.ittory.api.auth.exception;
+
+import static com.ittory.api.auth.exception.AuthErrorCode.NO_REFRESH_TOKEN;
+import static com.ittory.api.auth.exception.AuthErrorCode.REFRESH_TOKEN_NOT_MATCH;
+
+import com.ittory.common.exception.ErrorInfo;
+import com.ittory.common.exception.ErrorStatus;
+import com.ittory.common.exception.GlobalException;
+
+public class AuthException extends GlobalException {
+
+    public AuthException(ErrorStatus status, ErrorInfo<?> errorInfo) {
+        super(status, errorInfo);
+    }
+
+    public static class NoRefreshTokenException extends AuthException {
+        public NoRefreshTokenException() {
+            super(NO_REFRESH_TOKEN.getStatus(),
+                    new ErrorInfo<>(NO_REFRESH_TOKEN.getCode(), NO_REFRESH_TOKEN.getMessage()));
+        }
+    }
+
+    public static class RefreshTokenNotMatchException extends AuthException {
+        public RefreshTokenNotMatchException(String refreshToken) {
+            super(REFRESH_TOKEN_NOT_MATCH.getStatus(),
+                    new ErrorInfo<>(REFRESH_TOKEN_NOT_MATCH.getCode(), REFRESH_TOKEN_NOT_MATCH.getMessage(),
+                            refreshToken));
+        }
+    }
+
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/usecase/KaKaoLoginUseCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/usecase/KaKaoLoginUseCase.java
@@ -7,7 +7,6 @@ import com.ittory.common.jwt.JwtProvider;
 import com.ittory.domain.member.domain.Member;
 import com.ittory.domain.member.service.MemberDomainService;
 import com.ittory.infra.oauth.kakao.KaKaoPlatformClient;
-import com.ittory.infra.oauth.kakao.dto.KaKaoTokenResponse;
 import com.ittory.infra.oauth.kakao.dto.MemberInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,8 +21,10 @@ public class KaKaoLoginUseCase {
     private final MemberDomainService memberDomainService;
 
     public AuthTokenResponse execute(String code) {
-        KaKaoTokenResponse kaKaoToken = kaKaoPlatformClient.getToken(code);
-        MemberInfo memberInfo = kaKaoPlatformClient.getMemberInfo(kaKaoToken.getAccessToken());
+//        KaKaoTokenResponse kaKaoToken = kaKaoPlatformClient.getToken(code);
+//        System.out.println(kaKaoToken.getAccessToken());
+//        MemberInfo memberInfo = kaKaoPlatformClient.getMemberInfo(kaKaoToken.getAccessToken());
+        MemberInfo memberInfo = kaKaoPlatformClient.getMemberInfo(code);
         Member member = memberDomainService.findMemberBySocialId(memberInfo.getSocialId());
 
         if (member == null) {

--- a/ittory-api/src/main/java/com/ittory/api/auth/usecase/KaKaoLoginUseCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/usecase/KaKaoLoginUseCase.java
@@ -7,6 +7,7 @@ import com.ittory.common.jwt.JwtProvider;
 import com.ittory.domain.member.domain.Member;
 import com.ittory.domain.member.service.MemberDomainService;
 import com.ittory.infra.oauth.kakao.KaKaoPlatformClient;
+import com.ittory.infra.oauth.kakao.dto.KaKaoTokenResponse;
 import com.ittory.infra.oauth.kakao.dto.MemberInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,10 +22,8 @@ public class KaKaoLoginUseCase {
     private final MemberDomainService memberDomainService;
 
     public AuthTokenResponse execute(String code) {
-//        KaKaoTokenResponse kaKaoToken = kaKaoPlatformClient.getToken(code);
-//        System.out.println(kaKaoToken.getAccessToken());
-//        MemberInfo memberInfo = kaKaoPlatformClient.getMemberInfo(kaKaoToken.getAccessToken());
-        MemberInfo memberInfo = kaKaoPlatformClient.getMemberInfo(code);
+        KaKaoTokenResponse kaKaoToken = kaKaoPlatformClient.getToken(code);
+        MemberInfo memberInfo = kaKaoPlatformClient.getMemberInfo(kaKaoToken.getAccessToken());
         Member member = memberDomainService.findMemberBySocialId(memberInfo.getSocialId());
 
         if (member == null) {

--- a/ittory-api/src/main/java/com/ittory/api/auth/usecase/KaKaoLoginUseCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/usecase/KaKaoLoginUseCase.java
@@ -1,0 +1,46 @@
+package com.ittory.api.auth.usecase;
+
+import static com.ittory.common.constant.MemberRole.MEMBER;
+
+import com.ittory.api.auth.dto.AuthTokenResponse;
+import com.ittory.common.jwt.JwtProvider;
+import com.ittory.domain.member.domain.Member;
+import com.ittory.domain.member.service.MemberDomainService;
+import com.ittory.infra.oauth.kakao.KaKaoPlatformClient;
+import com.ittory.infra.oauth.kakao.dto.KaKaoTokenResponse;
+import com.ittory.infra.oauth.kakao.dto.MemberInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KaKaoLoginUseCase {
+
+    private final KaKaoPlatformClient kaKaoPlatformClient;
+    private final JwtProvider jwtProvider;
+
+    private final MemberDomainService memberDomainService;
+
+    public AuthTokenResponse execute(String code) {
+        KaKaoTokenResponse kaKaoToken = kaKaoPlatformClient.getToken(code);
+        MemberInfo memberInfo = kaKaoPlatformClient.getMemberInfo(kaKaoToken.getAccessToken());
+        Member member = memberDomainService.findMemberBySocialId(memberInfo.getSocialId());
+
+        if (member == null) {
+            member = memberDomainService.saveMember(
+                    memberInfo.getSocialId(),
+                    memberInfo.getName(),
+                    memberInfo.getProfileUrl()
+            );
+        }
+
+        return generateMemberToken(member);
+    }
+
+    private AuthTokenResponse generateMemberToken(Member member) {
+        String memberAccessToken = jwtProvider.createAccessToken(member.getId(), MEMBER);
+        String memberRefreshToken = jwtProvider.createRefreshToken(member.getId());
+        memberDomainService.changeRefreshToken(member, memberRefreshToken);
+        return AuthTokenResponse.of(memberAccessToken, memberRefreshToken);
+    }
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/usecase/LogoutUseCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/usecase/LogoutUseCase.java
@@ -1,0 +1,18 @@
+package com.ittory.api.auth.usecase;
+
+import com.ittory.domain.member.domain.Member;
+import com.ittory.domain.member.service.MemberDomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutUseCase {
+
+    private final MemberDomainService memberDomainService;
+
+    public void execute(Member member) {
+        memberDomainService.changeRefreshToken(member, null);
+    }
+
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/usecase/TokenRefreshUseCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/usecase/TokenRefreshUseCase.java
@@ -3,6 +3,8 @@ package com.ittory.api.auth.usecase;
 import static com.ittory.common.constant.MemberRole.MEMBER;
 
 import com.ittory.api.auth.dto.TokenRefreshResponse;
+import com.ittory.api.auth.exception.AuthException.NoRefreshTokenException;
+import com.ittory.api.auth.exception.AuthException.RefreshTokenNotMatchException;
 import com.ittory.common.jwt.JwtProvider;
 import com.ittory.domain.member.domain.Member;
 import com.ittory.domain.member.service.MemberDomainService;
@@ -21,11 +23,11 @@ public class TokenRefreshUseCase {
         Member member = memberDomainService.findMemberById(memberId);
 
         if (member.getRefreshToken() == null) {
-            throw new IllegalArgumentException();
+            throw new NoRefreshTokenException();
         }
 
         if (!member.getRefreshToken().equals(refreshToken)) {
-            throw new IllegalArgumentException();
+            throw new RefreshTokenNotMatchException(refreshToken);
         }
 
         String newCreatedAccessToken = newCreatedAccessToken(memberId);

--- a/ittory-api/src/main/java/com/ittory/api/auth/usecase/TokenRefreshUseCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/usecase/TokenRefreshUseCase.java
@@ -1,0 +1,40 @@
+package com.ittory.api.auth.usecase;
+
+import static com.ittory.common.constant.MemberRole.MEMBER;
+
+import com.ittory.api.auth.dto.TokenRefreshResponse;
+import com.ittory.common.jwt.JwtProvider;
+import com.ittory.domain.member.domain.Member;
+import com.ittory.domain.member.service.MemberDomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenRefreshUseCase {
+
+    private final JwtProvider jwtProvider;
+    private final MemberDomainService memberDomainService;
+
+    public TokenRefreshResponse execute(String accessToken, String refreshToken) {
+        Long memberId = jwtProvider.getSubByExpiredToken(accessToken);
+        Member member = memberDomainService.findMemberById(memberId);
+
+        if (member.getRefreshToken() == null) {
+            throw new IllegalArgumentException();
+        }
+
+        if (!member.getRefreshToken().equals(refreshToken)) {
+            throw new IllegalArgumentException();
+        }
+
+        String newCreatedAccessToken = newCreatedAccessToken(memberId);
+
+        return TokenRefreshResponse.of(newCreatedAccessToken);
+
+    }
+
+    private String newCreatedAccessToken(Long memberId) {
+        return jwtProvider.createAccessToken(memberId, MEMBER);
+    }
+}

--- a/ittory-api/src/main/java/com/ittory/api/common/exception/GlobalExceptionHandler.java
+++ b/ittory-api/src/main/java/com/ittory/api/common/exception/GlobalExceptionHandler.java
@@ -43,6 +43,8 @@ public class GlobalExceptionHandler {
         log.error(LOG_FORMAT, "MethodArgumentNotValidException", exception.getClass().getSimpleName(),
                 exception.getMessage());
 
+        System.out.println(exception.getMessage());
+
         CommonErrorCode errorCode = CommonErrorCode.INVALID_REQUEST_CONTENT;
         ErrorInfo<?> errorInfo = new ErrorInfo<>(errorCode.getCode(), errorCode.getMessage(),
                 exception.getDetailMessageArguments());

--- a/ittory-api/src/main/java/com/ittory/api/config/security/SecurityConfig.java
+++ b/ittory-api/src/main/java/com/ittory/api/config/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.ittory.api.config.security;
 
+import static com.ittory.common.constant.DBConstant.H2_PATH;
+
 import com.ittory.api.config.security.filter.CustomAuthenticationEntryPoint;
 import com.ittory.api.config.security.filter.ExceptionHandlerFilter;
 import com.ittory.api.config.security.filter.JwtAuthenticationFilter;
@@ -29,11 +31,13 @@ public class SecurityConfig {
         http
                 .cors(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
+                .headers(header -> header.frameOptions(FrameOptionsConfig::sameOrigin))
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers(H2_PATH).permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling((config) -> config.authenticationEntryPoint(customAuthenticationEntryPoint))

--- a/ittory-api/src/main/java/com/ittory/api/config/security/SecurityConfig.java
+++ b/ittory-api/src/main/java/com/ittory/api/config/security/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers(H2_PATH).permitAll()
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/auth/login/**", "/api/auth/refresh").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling((config) -> config.authenticationEntryPoint(customAuthenticationEntryPoint))

--- a/ittory-api/src/main/java/com/ittory/api/config/security/SecurityConfig.java
+++ b/ittory-api/src/main/java/com/ittory/api/config/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -32,11 +33,10 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((authorize) -> authorize
-                        .anyRequest().permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
                 )
-                .exceptionHandling(
-                        (config) -> config.authenticationEntryPoint(customAuthenticationEntryPoint)
-                )
+                .exceptionHandling((config) -> config.authenticationEntryPoint(customAuthenticationEntryPoint))
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
                         UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);

--- a/ittory-api/src/main/java/com/ittory/api/config/security/SecurityConfig.java
+++ b/ittory-api/src/main/java/com/ittory/api/config/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers(H2_PATH).permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling((config) -> config.authenticationEntryPoint(customAuthenticationEntryPoint))

--- a/ittory-api/src/main/java/com/ittory/api/config/security/filter/CustomAuthenticationEntryPoint.java
+++ b/ittory-api/src/main/java/com/ittory/api/config/security/filter/CustomAuthenticationEntryPoint.java
@@ -1,5 +1,7 @@
 package com.ittory.api.config.security.filter;
 
+import static com.ittory.common.constant.TokenConstant.ACCESS_TOKEN_HEADER;
+
 import com.ittory.common.jwt.exception.JwtException.NoAccessTokenException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -16,7 +18,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) {
-        if (request.getHeader("Authorization") == null) {
+        if (request.getHeader(ACCESS_TOKEN_HEADER) == null) {
             throw new NoAccessTokenException();
         }
     }

--- a/ittory-api/src/main/java/com/ittory/api/config/security/filter/JwtAuthenticationFilter.java
+++ b/ittory-api/src/main/java/com/ittory/api/config/security/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.ittory.api.config.security.filter;
 
+import static com.ittory.common.constant.TokenConstant.ACCESS_TOKEN_HEADER;
+
 import com.ittory.api.auth.dto.MemberDetails;
 import com.ittory.common.jwt.AccessTokenInfo;
 import com.ittory.common.jwt.JwtProvider;
@@ -34,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String getTokenByHeader(HttpServletRequest request) {
-        return request.getHeader("Authorization");
+        return request.getHeader(ACCESS_TOKEN_HEADER);
     }
 
     private Authentication getAuthentication(String accessToken) {

--- a/ittory-api/src/main/java/com/ittory/api/member/controller/MemberController.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/controller/MemberController.java
@@ -1,15 +1,11 @@
 package com.ittory.api.member.controller;
 
-import com.ittory.api.member.dto.MemberCreateRequest;
-import com.ittory.api.member.dto.MemberCreateResponse;
 import com.ittory.api.member.dto.MemberSearchResponse;
 import com.ittory.api.member.usecase.MemberUserCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,15 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberUserCase memberUserCase;
-
-    @PostMapping("")
-    public ResponseEntity<MemberCreateResponse> createMember(@RequestBody MemberCreateRequest memberCreateRequest) {
-        MemberCreateResponse response = memberUserCase.registerMember(
-                memberCreateRequest.getSocialId(),
-                memberCreateRequest.getName()
-        );
-        return ResponseEntity.ok().body(response);
-    }
 
     @GetMapping("/{memberId}")
     public ResponseEntity<MemberSearchResponse> searchMemberById(@PathVariable("memberId") Long memberId) {

--- a/ittory-api/src/main/java/com/ittory/api/member/controller/MemberController.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/controller/MemberController.java
@@ -23,7 +23,7 @@ public class MemberController {
     @PostMapping("")
     public ResponseEntity<MemberCreateResponse> createMember(@RequestBody MemberCreateRequest memberCreateRequest) {
         MemberCreateResponse response = memberUserCase.registerMember(
-                memberCreateRequest.getEmail(),
+                memberCreateRequest.getSocialId(),
                 memberCreateRequest.getName()
         );
         return ResponseEntity.ok().body(response);

--- a/ittory-api/src/main/java/com/ittory/api/member/dto/MemberCreateRequest.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/dto/MemberCreateRequest.java
@@ -6,6 +6,6 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class MemberCreateRequest {
-    private String email;
+    private Long socialId;
     private String name;
 }

--- a/ittory-api/src/main/java/com/ittory/api/member/dto/MemberCreateRequest.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/dto/MemberCreateRequest.java
@@ -8,4 +8,5 @@ import lombok.NoArgsConstructor;
 public class MemberCreateRequest {
     private Long socialId;
     private String name;
+    private String profileImage;
 }

--- a/ittory-api/src/main/java/com/ittory/api/member/dto/MemberCreateResponse.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/dto/MemberCreateResponse.java
@@ -12,13 +12,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MemberCreateResponse {
     private Long id;
-    private String email;
+    private Long socialId;
     private String name;
 
     public static MemberCreateResponse from(Member member) {
         return MemberCreateResponse.builder()
                 .id(member.getId())
-                .email(member.getEmail())
+                .socialId(member.getSocialId())
                 .name(member.getName())
                 .build();
     }

--- a/ittory-api/src/main/java/com/ittory/api/member/dto/MemberSearchResponse.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/dto/MemberSearchResponse.java
@@ -14,12 +14,14 @@ public class MemberSearchResponse {
     private Long id;
     private Long socialId;
     private String name;
+    private String refreshToken;
 
     public static MemberSearchResponse from(Member member) {
         return MemberSearchResponse.builder()
                 .id(member.getId())
                 .socialId(member.getSocialId())
                 .name(member.getName())
+                .refreshToken(member.getRefreshToken())
                 .build();
     }
 }

--- a/ittory-api/src/main/java/com/ittory/api/member/dto/MemberSearchResponse.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/dto/MemberSearchResponse.java
@@ -12,13 +12,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MemberSearchResponse {
     private Long id;
-    private String email;
+    private Long socialId;
     private String name;
 
     public static MemberSearchResponse from(Member member) {
         return MemberSearchResponse.builder()
                 .id(member.getId())
-                .email(member.getEmail())
+                .socialId(member.getSocialId())
                 .name(member.getName())
                 .build();
     }

--- a/ittory-api/src/main/java/com/ittory/api/member/exception/MemberErrorCode.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/exception/MemberErrorCode.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum MemberErrorCode {
 
-    MEMBER_NOT_FOUND(BAD_REQUEST, "1000", "존재하지 않는 사용자입니다.");
+    MEMBER_NOT_FOUND_ERROR(BAD_REQUEST, "1000", "존재하지 않는 사용자입니다.");
 
     private final ErrorStatus status;
     private final String code;

--- a/ittory-api/src/main/java/com/ittory/api/member/exception/MemberException.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/exception/MemberException.java
@@ -1,6 +1,6 @@
 package com.ittory.api.member.exception;
 
-import static com.ittory.api.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+import static com.ittory.api.member.exception.MemberErrorCode.MEMBER_NOT_FOUND_ERROR;
 
 import com.ittory.common.exception.ErrorInfo;
 import com.ittory.common.exception.ErrorStatus;
@@ -14,8 +14,8 @@ public class MemberException extends GlobalException {
 
     public static class MemberNotFoundException extends MemberException {
         public MemberNotFoundException(Long memberId) {
-            super(MEMBER_NOT_FOUND.getStatus(),
-                    new ErrorInfo<>(MEMBER_NOT_FOUND.getCode(), MEMBER_NOT_FOUND.getMessage(), memberId));
+            super(MEMBER_NOT_FOUND_ERROR.getStatus(),
+                    new ErrorInfo<>(MEMBER_NOT_FOUND_ERROR.getCode(), MEMBER_NOT_FOUND_ERROR.getMessage(), memberId));
         }
     }
 }

--- a/ittory-api/src/main/java/com/ittory/api/member/usecase/MemberUserCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/usecase/MemberUserCase.java
@@ -13,8 +13,8 @@ public class MemberUserCase {
 
     private final MemberDomainService memberDomainService;
 
-    public MemberCreateResponse registerMember(String email, String name) {
-        Member newMember = memberDomainService.saveMember(email, name);
+    public MemberCreateResponse registerMember(Long socialId, String name) {
+        Member newMember = memberDomainService.saveMember(socialId, name);
         return MemberCreateResponse.from(newMember);
     }
 

--- a/ittory-api/src/main/java/com/ittory/api/member/usecase/MemberUserCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/usecase/MemberUserCase.java
@@ -13,8 +13,8 @@ public class MemberUserCase {
 
     private final MemberDomainService memberDomainService;
 
-    public MemberCreateResponse registerMember(Long socialId, String name) {
-        Member newMember = memberDomainService.saveMember(socialId, name);
+    public MemberCreateResponse registerMember(Long socialId, String name, String profileImage) {
+        Member newMember = memberDomainService.saveMember(socialId, name, profileImage);
         return MemberCreateResponse.from(newMember);
     }
 

--- a/ittory-api/src/test/java/com/ittory/api/auth/usecase/KaKaoLoginUseCaseTest.java
+++ b/ittory-api/src/test/java/com/ittory/api/auth/usecase/KaKaoLoginUseCaseTest.java
@@ -1,0 +1,90 @@
+package com.ittory.api.auth.usecase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.ittory.api.auth.dto.AuthTokenResponse;
+import com.ittory.common.jwt.JwtProvider;
+import com.ittory.domain.member.domain.Member;
+import com.ittory.domain.member.enums.MemberStatus;
+import com.ittory.domain.member.service.MemberDomainService;
+import com.ittory.infra.oauth.kakao.KaKaoPlatformClient;
+import com.ittory.infra.oauth.kakao.dto.KaKaoTokenResponse;
+import com.ittory.infra.oauth.kakao.dto.MemberInfo;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class KaKaoLoginUseCaseTest {
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private MemberDomainService memberDomainService;
+    @Mock
+    private KaKaoPlatformClient kaKaoPlatformClient;
+
+    @InjectMocks
+    private KaKaoLoginUseCase kaKaoLoginUseCase;
+
+    //Member.create(1L, "test man", null)
+    @Test
+    void executeTest_Save() {
+        //given
+        String kakaoCode = "kakao_code";
+        String kakaoAccessToken = "kakao_access_token";
+        Member member = Member.builder()
+                .id(1L)
+                .socialId(1L)
+                .name("test man")
+                .profileImage(null)
+                .memberStatus(MemberStatus.ACTIVE)
+                .refreshToken(null)
+                .build();
+
+        when(kaKaoPlatformClient.getToken(any(String.class))).thenReturn(new KaKaoTokenResponse(kakaoAccessToken));
+        when(kaKaoPlatformClient.getMemberInfo(any(String.class))).thenReturn(new MemberInfo(1L, "test man", null));
+        when(memberDomainService.findMemberBySocialId(any(Long.class))).thenReturn(null);
+        when(memberDomainService.saveMember(1L, "test man", null)).thenReturn(member);
+        when(jwtProvider.createAccessToken(any(Long.class), any(String.class))).thenReturn("access.token");
+        when(jwtProvider.createRefreshToken(any(Long.class))).thenReturn("refresh.token");
+
+        //when
+        AuthTokenResponse execute = kaKaoLoginUseCase.execute(kakaoCode);
+
+        Assertions.assertThat(execute.getAccessToken()).isEqualTo("access.token");
+        Assertions.assertThat(execute.getRefreshToken()).isEqualTo("refresh.token");
+    }
+
+    @Test
+    void executeTest_Find() {
+        //given
+        String kakaoCode = "kakao_code";
+        String kakaoAccessToken = "kakao_access_token";
+        Member member = Member.builder()
+                .id(1L)
+                .socialId(1L)
+                .name("test man")
+                .profileImage(null)
+                .memberStatus(MemberStatus.ACTIVE)
+                .refreshToken(null)
+                .build();
+
+        when(kaKaoPlatformClient.getToken(any(String.class))).thenReturn(new KaKaoTokenResponse(kakaoAccessToken));
+        when(kaKaoPlatformClient.getMemberInfo(any(String.class))).thenReturn(new MemberInfo(1L, "test man", null));
+        when(memberDomainService.findMemberBySocialId(any(Long.class))).thenReturn(member);
+        when(jwtProvider.createAccessToken(any(Long.class), any(String.class))).thenReturn("access.token");
+        when(jwtProvider.createRefreshToken(any(Long.class))).thenReturn("refresh.token");
+
+        //when
+        AuthTokenResponse execute = kaKaoLoginUseCase.execute(kakaoCode);
+
+        Assertions.assertThat(execute.getAccessToken()).isEqualTo("access.token");
+        Assertions.assertThat(execute.getRefreshToken()).isEqualTo("refresh.token");
+    }
+
+}

--- a/ittory-api/src/test/java/com/ittory/api/auth/usecase/LogoutUseCaseTest.java
+++ b/ittory-api/src/test/java/com/ittory/api/auth/usecase/LogoutUseCaseTest.java
@@ -1,0 +1,41 @@
+package com.ittory.api.auth.usecase;
+
+import static org.mockito.Mockito.verify;
+
+import com.ittory.domain.member.domain.Member;
+import com.ittory.domain.member.enums.MemberStatus;
+import com.ittory.domain.member.service.MemberDomainService;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class LogoutUseCaseTest {
+
+    @Mock
+    private MemberDomainService memberDomainService;
+
+    @InjectMocks
+    private LogoutUseCase logoutUseCase;
+
+    @Test
+    void executeTest() {
+        //given
+        Member member = Member.builder()
+                .id(1L)
+                .socialId(1L)
+                .name("test man")
+                .profileImage(null)
+                .memberStatus(MemberStatus.ACTIVE)
+                .refreshToken("old.refresh.token")
+                .build();
+
+        //when
+        logoutUseCase.execute(member);
+
+        //then
+        verify(memberDomainService).changeRefreshToken(member, null);
+    }
+
+}

--- a/ittory-api/src/test/java/com/ittory/api/auth/usecase/TokenRefreshUseCaseTest.java
+++ b/ittory-api/src/test/java/com/ittory/api/auth/usecase/TokenRefreshUseCaseTest.java
@@ -1,0 +1,108 @@
+package com.ittory.api.auth.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.ittory.api.auth.dto.TokenRefreshResponse;
+import com.ittory.api.auth.exception.AuthException.NoRefreshTokenException;
+import com.ittory.api.auth.exception.AuthException.RefreshTokenNotMatchException;
+import com.ittory.common.jwt.JwtProvider;
+import com.ittory.domain.member.domain.Member;
+import com.ittory.domain.member.enums.MemberStatus;
+import com.ittory.domain.member.service.MemberDomainService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class TokenRefreshUseCaseTest {
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private MemberDomainService memberDomainService;
+
+    @InjectMocks
+    private TokenRefreshUseCase tokenRefreshUseCase;
+
+    @DisplayName("리프레시 토큰으로 엑세스 토큰을 갱신할 수 있다.")
+    @Test
+    void executeTest() {
+        //given
+        String accessToken = "expired.access.token";
+        String refreshToken = "member.refresh.token";
+        Member member = Member.builder()
+                .id(1L)
+                .socialId(1L)
+                .name("test man")
+                .profileImage(null)
+                .memberStatus(MemberStatus.ACTIVE)
+                .refreshToken(refreshToken)
+                .build();
+
+        when(jwtProvider.getSubByExpiredToken(any(String.class))).thenReturn(1L);
+        when(memberDomainService.findMemberById(any(Long.class))).thenReturn(member);
+        when(jwtProvider.createAccessToken(any(Long.class), any(String.class))).thenReturn("new.access.token");
+
+        //when
+        TokenRefreshResponse execute = tokenRefreshUseCase.execute(accessToken, refreshToken);
+
+        //then
+        assertThat(execute.getAccessToken()).isEqualTo("new.access.token");
+
+    }
+
+    @DisplayName("사용자 DB에 리프레시 토큰이 없으면 예외 발생.")
+    @Test
+    void executeTest_NoRefreshTokenException() {
+        //given
+        String accessToken = "expired.access.token";
+        String refreshToken = "member.refresh.token";
+        Member member = Member.builder()
+                .id(1L)
+                .socialId(1L)
+                .name("test man")
+                .profileImage(null)
+                .memberStatus(MemberStatus.ACTIVE)
+                .refreshToken(null)
+                .build();
+
+        when(jwtProvider.getSubByExpiredToken(any(String.class))).thenReturn(1L);
+        when(memberDomainService.findMemberById(any(Long.class))).thenReturn(member);
+
+        //when & then
+        assertThatThrownBy(() -> tokenRefreshUseCase.execute(accessToken, refreshToken))
+                .isInstanceOf(NoRefreshTokenException.class);
+
+    }
+
+    @DisplayName("리프레시 토큰이 일치하지 않으면 예외 발생.")
+    @Test
+    void executeTest_RefreshTokenNotMatchException() {
+        //given
+        String accessToken = "expired.access.token";
+        String refreshToken = "wrong.refresh.token";
+        Member member = Member.builder()
+                .id(1L)
+                .socialId(1L)
+                .name("test man")
+                .profileImage(null)
+                .memberStatus(MemberStatus.ACTIVE)
+                .refreshToken("member.refresh.token")
+                .build();
+
+        when(jwtProvider.getSubByExpiredToken(any(String.class))).thenReturn(1L);
+        when(memberDomainService.findMemberById(any(Long.class))).thenReturn(member);
+
+        //when & then
+        assertThatThrownBy(() -> tokenRefreshUseCase.execute(accessToken, refreshToken))
+                .isInstanceOf(RefreshTokenNotMatchException.class);
+
+    }
+
+}

--- a/ittory-common/src/main/java/com/ittory/common/constant/DBConstant.java
+++ b/ittory-common/src/main/java/com/ittory/common/constant/DBConstant.java
@@ -1,0 +1,7 @@
+package com.ittory.common.constant;
+
+public class DBConstant {
+
+    public static final String H2_PATH = "/h2-console/**";
+
+}

--- a/ittory-common/src/main/java/com/ittory/common/constant/MemberRole.java
+++ b/ittory-common/src/main/java/com/ittory/common/constant/MemberRole.java
@@ -1,0 +1,7 @@
+package com.ittory.common.constant;
+
+public class MemberRole {
+
+    public static final String MEMBER = "MEMBER";
+    public static final String ADMIN = "ADMIN";
+}

--- a/ittory-common/src/main/java/com/ittory/common/constant/TokenConstant.java
+++ b/ittory-common/src/main/java/com/ittory/common/constant/TokenConstant.java
@@ -1,0 +1,7 @@
+package com.ittory.common.constant;
+
+public class TokenConstant {
+
+    public static final String TOKEN_TYPER = "Bearer";
+    public static final String ACCESS_TOKEN_HEADER = "Authorization";
+}

--- a/ittory-common/src/main/java/com/ittory/common/jwt/JwtProvider.java
+++ b/ittory-common/src/main/java/com/ittory/common/jwt/JwtProvider.java
@@ -2,6 +2,8 @@ package com.ittory.common.jwt;
 
 import static com.ittory.common.constant.TokenConstant.TOKEN_TYPER;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ittory.common.jwt.exception.JwtException;
 import com.ittory.common.jwt.exception.JwtException.InvalidateTokenException;
 import com.ittory.common.jwt.exception.JwtException.UnSupportedTokenException;
@@ -92,6 +94,20 @@ public class JwtProvider {
             throw new UnSupportedTokenException(token);
         }
         return splitToken[1];
+    }
+
+    public Long getSubByExpiredToken(String token) {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            String[] splitToken = token.split("\\.");
+            String base64EncodedBody = splitToken[1];
+            String body = new String(Base64.getUrlDecoder().decode(base64EncodedBody));
+            JsonNode payloadJson = objectMapper.readTree(body);
+            return Long.parseLong(payloadJson.get("sub").asText());
+        } catch (Exception exception) {
+            throw new InvalidateTokenException(token);
+        }
     }
 
 }

--- a/ittory-common/src/main/java/com/ittory/common/jwt/JwtProvider.java
+++ b/ittory-common/src/main/java/com/ittory/common/jwt/JwtProvider.java
@@ -1,5 +1,7 @@
 package com.ittory.common.jwt;
 
+import static com.ittory.common.constant.TokenConstant.TOKEN_TYPER;
+
 import com.ittory.common.jwt.exception.JwtException;
 import com.ittory.common.jwt.exception.JwtException.InvalidateTokenException;
 import com.ittory.common.jwt.exception.JwtException.UnSupportedTokenException;
@@ -26,9 +28,6 @@ public class JwtProvider {
     @Value("${spring.jwt.secret}")
     private String SECRET_KEY;
 
-    @Value("${spring.jwt.type}")
-    private String TOKEN_TYPE;
-
     @Value("${spring.jwt.token.access-expiration-time}")
     private Long ACCESS_TOKEN_EXPIRATION_TIME;
 
@@ -41,7 +40,6 @@ public class JwtProvider {
     }
 
     private Key getSecretKey() {
-        System.out.println(SECRET_KEY);
         return Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -89,8 +87,8 @@ public class JwtProvider {
     }
 
     private String getClaimsJws(String token) {
-        String[] splitToken = token.split(TOKEN_TYPE + " ");
-        if (!token.startsWith(TOKEN_TYPE + " ") && splitToken.length != 2) {
+        String[] splitToken = token.split(TOKEN_TYPER + " ");
+        if (!token.startsWith(TOKEN_TYPER + " ") && splitToken.length != 2) {
             throw new UnSupportedTokenException(token);
         }
         return splitToken[1];

--- a/ittory-common/src/main/resources/common.yml
+++ b/ittory-common/src/main/resources/common.yml
@@ -6,7 +6,6 @@ spring:
   profiles:
     active: local
   jwt:
-    type: Bearer
     secret: ${JWT_SECRET_KEY}
     token:
       access-expiration-time: ${JWT_ACCESS_EXPIRATION_TIME}

--- a/ittory-domain/build.gradle
+++ b/ittory-domain/build.gradle
@@ -2,4 +2,6 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation project(':ittory-common')
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/domain/Member.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/domain/Member.java
@@ -27,7 +27,7 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
-    private String email;
+    private Long socialId;
 
     private String name;
 
@@ -39,9 +39,9 @@ public class Member extends BaseEntity {
     private String refreshToken;
 
 
-    public static Member create(String email, String name, String profileImage) {
+    public static Member create(Long socialId, String name, String profileImage) {
         return Member.builder()
-                .email(email)
+                .socialId(socialId)
                 .name(name)
                 .profileImage(profileImage)
                 .memberStatus(MemberStatus.ACTIVE)

--- a/ittory-domain/src/main/java/com/ittory/domain/member/exception/MemberErrorCode.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/exception/MemberErrorCode.java
@@ -1,4 +1,4 @@
-package com.ittory.api.member.exception;
+package com.ittory.domain.member.exception;
 
 import static com.ittory.common.exception.ErrorStatus.BAD_REQUEST;
 
@@ -10,7 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum MemberErrorCode {
 
-    MEMBER_NOT_FOUND_ERROR(BAD_REQUEST, "1000", "존재하지 않는 사용자입니다.");
+    MEMBER_NOT_FOUND_ERROR(ErrorStatus.BAD_REQUEST, "1000", "존재하지 않는 사용자입니다.");
 
     private final ErrorStatus status;
     private final String code;

--- a/ittory-domain/src/main/java/com/ittory/domain/member/exception/MemberException.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/exception/MemberException.java
@@ -1,6 +1,6 @@
-package com.ittory.api.member.exception;
+package com.ittory.domain.member.exception;
 
-import static com.ittory.api.member.exception.MemberErrorCode.MEMBER_NOT_FOUND_ERROR;
+import static com.ittory.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND_ERROR;
 
 import com.ittory.common.exception.ErrorInfo;
 import com.ittory.common.exception.ErrorStatus;

--- a/ittory-domain/src/main/java/com/ittory/domain/member/repository/MemberRepository.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/repository/MemberRepository.java
@@ -1,7 +1,9 @@
 package com.ittory.domain.member.repository;
 
 import com.ittory.domain.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findBySocialId(Long socialId);
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
@@ -4,6 +4,7 @@ import com.ittory.domain.member.domain.Member;
 import com.ittory.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -11,18 +12,22 @@ public class MemberDomainService {
 
     private final MemberRepository memberDomainRepository;
 
+    @Transactional
     public Member saveMember(Long socialId, String name, String profileImage) {
         return memberDomainRepository.save(Member.create(socialId, name, profileImage));
     }
 
+    @Transactional(readOnly = true)
     public Member findMemberById(Long memberId) {
         return memberDomainRepository.findById(memberId).orElseThrow(IllegalArgumentException::new);
     }
 
+    @Transactional(readOnly = true)
     public Member findMemberBySocialId(Long socialId) {
         return memberDomainRepository.findBySocialId(socialId).orElse(null);
     }
 
+    @Transactional
     public void changeRefreshToken(Member member, String memberRefreshToken) {
         member.changeRefreshToken(memberRefreshToken);
         memberDomainRepository.save(member);

--- a/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
@@ -1,6 +1,7 @@
 package com.ittory.domain.member.service;
 
 import com.ittory.domain.member.domain.Member;
+import com.ittory.domain.member.exception.MemberException.MemberNotFoundException;
 import com.ittory.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,7 +20,7 @@ public class MemberDomainService {
 
     @Transactional(readOnly = true)
     public Member findMemberById(Long memberId) {
-        return memberDomainRepository.findById(memberId).orElseThrow(IllegalArgumentException::new);
+        return memberDomainRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
     }
 
     @Transactional(readOnly = true)

--- a/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
@@ -11,12 +11,21 @@ public class MemberDomainService {
 
     private final MemberRepository memberDomainRepository;
 
-    public Member saveMember(Long socialId, String name) {
-        return memberDomainRepository.save(Member.create(socialId, name, null));
+    public Member saveMember(Long socialId, String name, String profileImage) {
+        return memberDomainRepository.save(Member.create(socialId, name, profileImage));
     }
 
     public Member findMemberById(Long memberId) {
-
         return memberDomainRepository.findById(memberId).orElseThrow(IllegalArgumentException::new);
     }
+
+    public Member findMemberBySocialId(Long socialId) {
+        return memberDomainRepository.findBySocialId(socialId).orElse(null);
+    }
+
+    public void changeRefreshToken(Member member, String memberRefreshToken) {
+        member.changeRefreshToken(memberRefreshToken);
+        memberDomainRepository.save(member);
+    }
+
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
@@ -11,8 +11,8 @@ public class MemberDomainService {
 
     private final MemberRepository memberDomainRepository;
 
-    public Member saveMember(String email, String name) {
-        return memberDomainRepository.save(Member.create(email, name, null));
+    public Member saveMember(Long socialId, String name) {
+        return memberDomainRepository.save(Member.create(socialId, name, null));
     }
 
     public Member findMemberById(Long memberId) {

--- a/ittory-domain/src/main/resources/domain.yml
+++ b/ittory-domain/src/main/resources/domain.yml
@@ -24,11 +24,10 @@ spring:
   h2:
     console:
       enabled: true
-      path: /ittoryh2
 
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:~/ittory/ittoryh2;Auto_SERVER=TRUE
+    url: jdbc:h2:mem:ittroy
     username: sa
     password:
 

--- a/ittory-domain/src/test/java/com/ittory/domain/letter/domain/LetterTest.java
+++ b/ittory-domain/src/test/java/com/ittory/domain/letter/domain/LetterTest.java
@@ -15,7 +15,7 @@ public class LetterTest {
         // given
         Letter letter = Letter.create(null, null, null, null, "test-letter", null);
         String memberName = "test member";
-        Member member = Member.create("test@email.com", memberName, "http://member.Image");
+        Member member = Member.create(1L, memberName, "http://member.Image");
 
         // when
         letter.changeReceiver(member);

--- a/ittory-domain/src/test/java/com/ittory/domain/member/domain/MemberTest.java
+++ b/ittory-domain/src/test/java/com/ittory/domain/member/domain/MemberTest.java
@@ -13,7 +13,7 @@ public class MemberTest {
     @Test
     void changeMemberStatusTest() {
         // given
-        Member member = Member.create("test@email.com", "test member", "http://member.Image");
+        Member member = Member.create(1L, "test member", "http://member.Image");
 
         // when
         member.changeStatus(MemberStatus.BANDED);
@@ -26,7 +26,7 @@ public class MemberTest {
     @Test
     void changeMemberRefreshTokenTest() {
         // given
-        Member member = Member.create("test@email.com", "test member", "http://member.Image");
+        Member member = Member.create(1L, "test member", "http://member.Image");
         String refreshToken = "changed.refresh.token";
 
         // when

--- a/ittory-domain/src/test/java/com/ittory/domain/member/repository/MemberRepositoryTest.java
+++ b/ittory-domain/src/test/java/com/ittory/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.ittory.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ittory.domain.member.domain.Member;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    void clean() {
+        memberRepository.deleteAll();
+    }
+
+
+    @DisplayName("소셜 아이디로 사용자를 조회할 수 있다.")
+    @Test
+    void findBySocialIdTest() {
+        //given
+        Long socialId = 1L;
+        String name = "test member";
+        String profileImage = "profile url";
+        memberRepository.save(Member.create(socialId, name, profileImage));
+
+        //when
+        Member member = memberRepository.findBySocialId(socialId).orElse(null);
+
+        //then
+        assertThat(member).isNotNull();
+        assertThat(member.getSocialId()).isEqualTo(socialId);
+        assertThat(member.getName()).isEqualTo(name);
+
+    }
+
+}

--- a/ittory-domain/src/test/java/com/ittory/domain/member/service/MemberServiceTest.java
+++ b/ittory-domain/src/test/java/com/ittory/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,136 @@
+package com.ittory.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ittory.domain.member.domain.Member;
+import com.ittory.domain.member.exception.MemberException.MemberNotFoundException;
+import com.ittory.domain.member.repository.MemberRepository;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+@SpringBootTest
+public class MemberServiceTest {
+
+    @Autowired
+    private MemberDomainService memberDomainService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    void clean() {
+        memberRepository.deleteAll();
+    }
+
+    @DisplayName("멤버를 저장할 수 있다.")
+    @Test
+    void saveMemberTest() {
+        //given
+        Long socialId = 1L;
+        String name = "test member";
+        String profileImage = "profile url";
+
+        //when
+        memberDomainService.saveMember(socialId, name, profileImage);
+
+        //then
+        List<Member> allMembers = memberRepository.findAll();
+        assertThat(allMembers.size()).isEqualTo(1);
+        assertThat(allMembers.get(0).getName()).isEqualTo(name);
+    }
+
+    @DisplayName("멤버 아이디로 멤버를 조회할 수 있다.")
+    @Test
+    void findByMemberIdTest() {
+        //given
+        Long socialId = 1L;
+        String name = "test member";
+        String profileImage = "profile url";
+        Member newMember = Member.create(socialId, name, profileImage);
+        Member save = memberRepository.save(newMember);
+
+        //when
+        Member member = memberDomainService.findMemberById(save.getId());
+
+        //then
+        assertThat(member.getName()).isEqualTo(name);
+    }
+
+    @DisplayName("조회하는 멤버가 없다면 예외가 발생한다.")
+    @Test
+    void findByMemberIdTest_MemberNotFoundException() {
+        //given
+        Long socialId = 1L;
+        String name = "test member";
+        String profileImage = "profile url";
+        Member newMember = Member.create(socialId, name, profileImage);
+        memberRepository.save(newMember);
+
+        //when & then
+        assertThatThrownBy(() -> memberDomainService.findMemberById(2L))
+                .isInstanceOf(MemberNotFoundException.class);
+    }
+
+    @DisplayName("소셜 아이디로 멤버를 조회할 수 있다.")
+    @Test
+    void findBySocialIdTest() {
+        //given
+        Long socialId = 1L;
+        String name = "test member";
+        String profileImage = "profile url";
+        Member newMember = Member.create(socialId, name, profileImage);
+        memberRepository.save(newMember);
+
+        //when
+        Member member = memberDomainService.findMemberBySocialId(socialId);
+
+        //then
+        assertThat(member.getSocialId()).isEqualTo(socialId);
+        assertThat(member.getName()).isEqualTo(name);
+    }
+
+    @DisplayName("소셜 아이디가 일치하는 멤버가 없다면 Null을 반환한다.")
+    @Test
+    void findBySocialIdTest_Null() {
+        //given
+        Long socialId = 1L;
+        String name = "test member";
+        String profileImage = "profile url";
+        Member newMember = Member.create(socialId, name, profileImage);
+        memberRepository.save(newMember);
+
+        //when
+        Member member = memberDomainService.findMemberBySocialId(2L);
+
+        //then
+        assertThat(member).isNull();
+    }
+
+    @DisplayName("리프레시 토큰을변경 할 수 있다..")
+    @Test
+    void changeRefreshTokenTest() {
+        //given
+        Long socialId = 1L;
+        String name = "test member";
+        String profileImage = "profile url";
+        Member newMember = Member.create(socialId, name, profileImage);
+        memberRepository.save(newMember);
+
+        String refreshToken = "member.token.refresh";
+
+        //when
+        memberDomainService.changeRefreshToken(newMember, refreshToken);
+
+        //then
+        Member member = memberRepository.findById(newMember.getId()).orElse(null);
+        assertThat(member).isNotNull();
+        assertThat(member.getRefreshToken()).isEqualTo(refreshToken);
+    }
+
+}

--- a/ittory-infra/build.gradle
+++ b/ittory-infra/build.gradle
@@ -1,3 +1,6 @@
 dependencies {
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.232'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    api project(path: ':ittory-common')
 }

--- a/ittory-infra/src/main/java/com/ittory/infra/config/WebClientConfig.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/config/WebClientConfig.java
@@ -1,0 +1,41 @@
+package com.ittory.infra.config;
+
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+@Configuration
+public class WebClientConfig {
+
+    DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory();
+
+    HttpClient httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000);
+
+    @Bean
+    public WebClient webClient() {
+        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+        return WebClient.builder()
+                .uriBuilderFactory(factory)
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    @Bean
+    public ConnectionProvider connectionProvider() {
+        return ConnectionProvider.builder("http-pool")
+                .maxConnections(100)
+                .pendingAcquireTimeout(Duration.ofMillis(0))
+                .pendingAcquireMaxCount(-1)
+                .maxIdleTime(Duration.ofMillis(1000L))
+                .build();
+    }
+
+}

--- a/ittory-infra/src/main/java/com/ittory/infra/oauth/exception/OAuthErrorCode.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/oauth/exception/OAuthErrorCode.java
@@ -1,0 +1,21 @@
+package com.ittory.infra.oauth.exception;
+
+import static com.ittory.common.exception.ErrorStatus.BAD_REQUEST;
+import static com.ittory.common.exception.ErrorStatus.INTERNAL_SERVER;
+
+import com.ittory.common.exception.ErrorStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OAuthErrorCode {
+
+    UNAUTHORIZED_TOKEN_ERROR(BAD_REQUEST, "4000", "인증되지 않은 토큰입니다."),
+    OAUTH_SERVER_ERROR(INTERNAL_SERVER, "4001", "OAuth 인증서버 에러입니다."),
+    SOCIAL_MEMBER_NO_INFO_ERROR(BAD_REQUEST, "4002", "사용자의 소셜 정보가 없습니다.");
+
+    private final ErrorStatus status;
+    private final String code;
+    private final String message;
+}

--- a/ittory-infra/src/main/java/com/ittory/infra/oauth/exception/OAuthException.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/oauth/exception/OAuthException.java
@@ -1,0 +1,37 @@
+package com.ittory.infra.oauth.exception;
+
+import static com.ittory.infra.oauth.exception.OAuthErrorCode.OAUTH_SERVER_ERROR;
+import static com.ittory.infra.oauth.exception.OAuthErrorCode.SOCIAL_MEMBER_NO_INFO_ERROR;
+import static com.ittory.infra.oauth.exception.OAuthErrorCode.UNAUTHORIZED_TOKEN_ERROR;
+
+import com.ittory.common.exception.ErrorInfo;
+import com.ittory.common.exception.ErrorStatus;
+import com.ittory.common.exception.GlobalException;
+
+public class OAuthException extends GlobalException {
+
+    public OAuthException(ErrorStatus status, ErrorInfo<?> errorInfo) {
+        super(status, errorInfo);
+    }
+
+    public static class UnauthorizedTokenException extends OAuthException {
+        public UnauthorizedTokenException(String token) {
+            super(UNAUTHORIZED_TOKEN_ERROR.getStatus(),
+                    new ErrorInfo<>(UNAUTHORIZED_TOKEN_ERROR.getCode(), UNAUTHORIZED_TOKEN_ERROR.getMessage(), token));
+        }
+    }
+
+    public static class OAuthServerException extends OAuthException {
+        public OAuthServerException(String url) {
+            super(OAUTH_SERVER_ERROR.getStatus(),
+                    new ErrorInfo<>(OAUTH_SERVER_ERROR.getCode(), OAUTH_SERVER_ERROR.getMessage(), url));
+        }
+    }
+
+    public static class SocialMemberNoInfoException extends OAuthException {
+        public SocialMemberNoInfoException() {
+            super(SOCIAL_MEMBER_NO_INFO_ERROR.getStatus(),
+                    new ErrorInfo<>(SOCIAL_MEMBER_NO_INFO_ERROR.getCode(), SOCIAL_MEMBER_NO_INFO_ERROR.getMessage()));
+        }
+    }
+}

--- a/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/KaKaoPlatformClient.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/KaKaoPlatformClient.java
@@ -1,0 +1,76 @@
+package com.ittory.infra.oauth.kakao;
+
+import static com.ittory.common.constant.TokenConstant.ACCESS_TOKEN_HEADER;
+import static com.ittory.common.constant.TokenConstant.TOKEN_TYPER;
+
+import com.ittory.infra.oauth.exception.OAuthException.OAuthServerException;
+import com.ittory.infra.oauth.exception.OAuthException.SocialMemberNoInfoException;
+import com.ittory.infra.oauth.exception.OAuthException.UnauthorizedTokenException;
+import com.ittory.infra.oauth.kakao.dto.KaKaoMemberInfo;
+import com.ittory.infra.oauth.kakao.dto.KaKaoTokenResponse;
+import com.ittory.infra.oauth.kakao.dto.MemberInfo;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class KaKaoPlatformClient {
+
+    private static final String ACCESS_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String MEMBER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private static final String GRANT_TYPE = "authorization_code";
+
+    @Value("${kakao.clientId}")
+    private String CLIENT_ID;
+
+    @Value("${kakao.redirectUri}")
+    private String REDIRECT_URI;
+
+    @Value("${kakao.clientSecret}")
+    private String CLIENT_SECRET;
+
+    public KaKaoTokenResponse getToken(String code) {
+        WebClient client = WebClient.create();
+
+        Mono<KaKaoTokenResponse> kaKaoTokenResponseMono = client.post()
+                .uri(ACCESS_TOKEN_URL)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .body(BodyInserters.fromFormData("grant_type", GRANT_TYPE)
+                        .with("client_id", CLIENT_ID)
+                        .with("redirect_uri", REDIRECT_URI)
+                        .with("code", code)
+                        .with("client_secret", CLIENT_SECRET)
+                )
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError,
+                        response -> Mono.error(new UnauthorizedTokenException(code)))
+                .onStatus(HttpStatusCode::is5xxServerError,
+                        response -> Mono.error(new OAuthServerException(ACCESS_TOKEN_URL)))
+                .bodyToMono(KaKaoTokenResponse.class);
+
+        return kaKaoTokenResponseMono.blockOptional().orElseThrow(SocialMemberNoInfoException::new);
+    }
+
+    public MemberInfo getMemberInfo(String accessToken) {
+        WebClient client = WebClient.create();
+
+        Mono<KaKaoMemberInfo> memberInfo = client.get()
+                .uri(MEMBER_INFO_URL)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .header(ACCESS_TOKEN_HEADER, TOKEN_TYPER + " " + accessToken)
+                .retrieve()
+                .onStatus(HttpStatusCode::is5xxServerError,
+                        response -> Mono.error(new OAuthServerException(MEMBER_INFO_URL)))
+                .bodyToMono(KaKaoMemberInfo.class);
+
+        KaKaoMemberInfo kaKaoMemberInfo = memberInfo.blockOptional().orElseThrow(SocialMemberNoInfoException::new);
+
+        return MemberInfo.from(kaKaoMemberInfo);
+    }
+}

--- a/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/KaKaoMemberInfo.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/KaKaoMemberInfo.java
@@ -1,0 +1,32 @@
+package com.ittory.infra.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KaKaoMemberInfo {
+
+    @JsonProperty("id")
+    private Long id;
+    @JsonProperty("kakao_account")
+    private KaKaoAccount kakaoAccount;
+
+    @Getter
+    public static class KaKaoAccount {
+        @JsonProperty("profile")
+        private KaKaoProfile profile;
+    }
+
+    @Getter
+    public static class KaKaoProfile {
+        @JsonProperty("nickname")
+        private String nickname;
+        @JsonProperty("thumbnail_image_url")
+        private String thumbnailImageUrl;
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
+        @JsonProperty("is_default_image")
+        private Boolean isDefaultImage;
+    }
+
+}

--- a/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/KaKaoTokenResponse.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/KaKaoTokenResponse.java
@@ -1,0 +1,12 @@
+package com.ittory.infra.oauth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KaKaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+}

--- a/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/KaKaoTokenResponse.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/KaKaoTokenResponse.java
@@ -1,9 +1,11 @@
 package com.ittory.infra.oauth.kakao.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class KaKaoTokenResponse {
 
     @JsonProperty("access_token")

--- a/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/MemberInfo.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/MemberInfo.java
@@ -1,0 +1,28 @@
+package com.ittory.infra.oauth.kakao.dto;
+
+import com.ittory.infra.oauth.kakao.dto.KaKaoMemberInfo.KaKaoProfile;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberInfo {
+
+    private Long socialId;
+    private String name;
+    private String profileUrl;
+
+    public static MemberInfo from(KaKaoMemberInfo kaKaoMemberInfo) {
+        KaKaoProfile profile = kaKaoMemberInfo.getKakaoAccount().getProfile();
+
+        // 기본 이미지면 null
+        String profileImageUrl = profile.getProfileImageUrl();
+        if (profile.getIsDefaultImage()) {
+            profileImageUrl = null;
+        }
+
+        return new MemberInfo(kaKaoMemberInfo.getId(), profile.getNickname(), profileImageUrl);
+    }
+
+}

--- a/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/MemberInfo.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/MemberInfo.java
@@ -1,12 +1,11 @@
 package com.ittory.infra.oauth.kakao.dto;
 
 import com.ittory.infra.oauth.kakao.dto.KaKaoMemberInfo.KaKaoProfile;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class MemberInfo {
 
     private Long socialId;

--- a/ittory-infra/src/main/resources/infra.yml
+++ b/ittory-infra/src/main/resources/infra.yml
@@ -13,6 +13,11 @@ aws:
     bucketName: ${S3_BUCKET_NAME}
     baseUrl: ${S3_BASE_URL}
 
+kakao:
+  clientId: ${KAKAO_CLIENT_ID}
+  redirectUri: ${KAKAO_REDIRECT_URI}
+  clientSecret: ${KAKAO_CLIENT_SECRET}
+
 ---
 spring:
   config:


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-51 -> develop

### :memo:변경 사항
- 카카오 로그인 기능 추가.
- Member 이메일 -> Member Social id로 변경.
- Spring Security H2 콘솔 접속 권한 수정.
- 리프레시 토큰으로 엑세스 토큰 갱신 기능 추가.
- 로그아웃 기능 추가.
- 추가된 기능의 테스트 코드 작성.
- ittroy-api 모듈 build 시 ittory-domain, ittory-common, ittory-infra의 Test 코드로 함께 검증.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
= Build 성공 =
<img width="667" alt="스크린샷 2024-07-27 오후 3 08 07" src="https://github.com/user-attachments/assets/da9e482b-0b54-4ad3-9c91-5b090e41bd84">

= ittory-api의 Test 실패 시 =
<img width="994" alt="스크린샷 2024-07-27 오후 3 09 36" src="https://github.com/user-attachments/assets/0bd76ac5-af45-4868-b381-cbb16e8c0499">

= ittory-domain의 Test 실패 시 =
<img width="923" alt="스크린샷 2024-07-27 오후 3 08 46" src="https://github.com/user-attachments/assets/3c8fa0f9-efbf-4f16-8f0c-392568ab2ee4">
