### PR TITLE
Bugfix/RL1M-148

### DIFF
--- a/ittory-api/src/main/java/com/ittory/api/config/swagger/SwaggerConfig.java
+++ b/ittory-api/src/main/java/com/ittory/api/config/swagger/SwaggerConfig.java
@@ -1,6 +1,7 @@
 package com.ittory.api.config.swagger;
 
 
+import com.ittory.common.annotation.CurrentMemberId;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -9,9 +10,12 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.Schema;
+import org.springdoc.core.customizers.GlobalOperationCustomizer;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
 
 
 @Configuration
@@ -53,6 +57,16 @@ public class SwaggerConfig {
         wrapperSchema.addProperty("data", originalSchema);
 
         return wrapperSchema;
+    }
+
+    @Bean
+    public GlobalOperationCustomizer customize() {
+        return (operation, handlerMethod) -> {
+            Arrays.stream(handlerMethod.getMethodParameters())
+                    .filter(param -> param.hasParameterAnnotation(CurrentMemberId.class))
+                    .forEach(param -> operation.getParameters().remove(param.getParameterIndex()));
+            return operation;
+        };
     }
 
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/letter/service/LetterDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/service/LetterDomainService.java
@@ -9,14 +9,14 @@ import com.ittory.domain.letter.repository.CoverTypeRepository;
 import com.ittory.domain.letter.repository.FontRepository;
 import com.ittory.domain.letter.repository.LetterElementRepository;
 import com.ittory.domain.letter.repository.LetterRepository;
-import com.ittory.domain.member.exception.MemberException.MemberNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -91,7 +91,7 @@ public class LetterDomainService {
 
     @Transactional(readOnly = true)
     public Letter findLetter(Long letterId) {
-        return letterRepository.findById(letterId).orElseThrow(() -> new MemberNotFoundException(letterId));
+        return letterRepository.findById(letterId).orElseThrow(() -> new LetterException.LetterNotFoundException(letterId));
     }
 
     @Transactional


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- bugfix/RL1M-148 -> develop

### :memo:변경 사항
- 편지 시작 시 정보조회 API 예외처리 수정.
    - MemberNotFoundException -> LetterNotFoundException.
- Swagger 문서에서 CurrentMemberId 어노테이션이 파라미터로 등장하는 현상 수정.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
X