### PR TITLE
fix : 편지 요소 생성 에러 수정

### DIFF
--- a/ittory-domain/src/main/java/com/ittory/domain/letter/exception/LetterErrorCode.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/exception/LetterErrorCode.java
@@ -11,7 +11,8 @@ public enum LetterErrorCode {
     LETTER_NOT_FOUND_ERROR(ErrorStatus.NOT_FOUND, "1003", "해당 편지를 찾을 수 없습니다."),
     FONT_NOT_FOUND_ERROR(ErrorStatus.NOT_FOUND, "1001", "해당 폰트를 찾을 수 없습니다."),
     COVER_TYPE_NOT_FOUND_ERROR(ErrorStatus.NOT_FOUND, "1002", "해당 표지를 찾을 수 없습니다."),
-    ELEMENT_NOT_FOUND_ERROR(ErrorStatus.NOT_FOUND, "1004", "해당 편지 요소를 찾을 수 없습니다.");
+    ELEMENT_NOT_FOUND_ERROR(ErrorStatus.NOT_FOUND, "1004", "해당 편지 요소를 찾을 수 없습니다."),
+    REPEAT_COUNT_TOO_MANY_ERROR(ErrorStatus.NOT_FOUND, "1005", "요청한 반복 횟수가 요소 이미지 개수 보다 많습니다.");
 
     private final ErrorStatus status;
     private final String code;

--- a/ittory-domain/src/main/java/com/ittory/domain/letter/exception/LetterException.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/exception/LetterException.java
@@ -1,11 +1,11 @@
 package com.ittory.domain.letter.exception;
 
-import static com.ittory.domain.letter.exception.LetterErrorCode.COVER_TYPE_NOT_FOUND_ERROR;
-import static com.ittory.domain.letter.exception.LetterErrorCode.FONT_NOT_FOUND_ERROR;
-
 import com.ittory.common.exception.ErrorInfo;
 import com.ittory.common.exception.ErrorStatus;
 import com.ittory.common.exception.GlobalException;
+
+import static com.ittory.domain.letter.exception.LetterErrorCode.COVER_TYPE_NOT_FOUND_ERROR;
+import static com.ittory.domain.letter.exception.LetterErrorCode.FONT_NOT_FOUND_ERROR;
 
 public class LetterException extends GlobalException {
 
@@ -41,6 +41,14 @@ public class LetterException extends GlobalException {
             super(LetterErrorCode.ELEMENT_NOT_FOUND_ERROR.getStatus(),
                     new ErrorInfo<>(LetterErrorCode.ELEMENT_NOT_FOUND_ERROR.getCode(),
                             LetterErrorCode.ELEMENT_NOT_FOUND_ERROR.getMessage()));
+        }
+    }
+
+    public static class RepeatCountTooManyException extends LetterException {
+        public RepeatCountTooManyException() {
+            super(LetterErrorCode.REPEAT_COUNT_TOO_MANY_ERROR.getStatus(),
+                    new ErrorInfo<>(LetterErrorCode.REPEAT_COUNT_TOO_MANY_ERROR.getCode(),
+                            LetterErrorCode.REPEAT_COUNT_TOO_MANY_ERROR.getMessage()));
         }
     }
 }


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- bugfix/RL1M-156 -> develop

### :memo:변경 사항
- 편지 요소 생성 시 요소 이미지가 null로 처리 되어 있던 부분 수정.
- DB에 있는 요소 이미지 중 랜덤으로 배정.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
<img width="598" alt="스크린샷 2024-10-24 오후 12 34 51" src="https://github.com/user-attachments/assets/985a8e3f-2f8f-4fa0-98f3-3e9bdd64f31b">
