### PR TITLE
fix : 편지 요소 생성 기능 수정

### DIFF
--- a/ittory-api/src/main/java/com/ittory/api/letter/usecase/LetterRepeatCountUseCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/letter/usecase/LetterRepeatCountUseCase.java
@@ -2,6 +2,7 @@ package com.ittory.api.letter.usecase;
 
 import com.ittory.api.letter.dto.LetterRepeatCountRequest;
 import com.ittory.domain.letter.domain.Letter;
+import com.ittory.domain.letter.service.ElementDomainService;
 import com.ittory.domain.letter.service.LetterDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,10 +12,12 @@ import org.springframework.stereotype.Service;
 public class LetterRepeatCountUseCase {
 
     private final LetterDomainService letterDomainService;
+    private final ElementDomainService elementDomainService;
 
     public void execute(LetterRepeatCountRequest request) {
         Letter letter = letterDomainService.findLetter(request.getLetterId());
+        elementDomainService.deleteAllByLetterId(letter.getId());
         letterDomainService.changeRepeatCount(letter, request.getRepeatCount());
-        letterDomainService.createLetterElements(request.getLetterId(), request.getRepeatCount());
+        letterDomainService.createLetterElements(letter, request.getRepeatCount());
     }
 }

--- a/ittory-api/src/main/java/com/ittory/api/letter/usecase/LetterStartInfoReadUseCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/letter/usecase/LetterStartInfoReadUseCase.java
@@ -4,11 +4,11 @@ import com.ittory.api.letter.dto.LetterStartInfoResponse;
 import com.ittory.domain.letter.domain.Element;
 import com.ittory.domain.letter.domain.Letter;
 import com.ittory.domain.letter.service.LetterDomainService;
-import com.ittory.domain.participant.domain.Participant;
 import com.ittory.domain.participant.service.ParticipantDomainService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,8 +20,8 @@ public class LetterStartInfoReadUseCase {
     public LetterStartInfoResponse execute(Long letterId) {
         Letter letter = letterDomainService.findLetter(letterId);
         List<Element> elements = letterDomainService.findElementsByLetterId(letterId);
-        List<Participant> participants = participantDomainService.findAllParticipants(letterId);
-        return LetterStartInfoResponse.of(participants.size(), letter.getRepeatCount(), elements.size());
+        Integer participantCount = participantDomainService.countProgressByLetterId(letterId);
+        return LetterStartInfoResponse.of(participantCount, letter.getRepeatCount(), elements.size());
     }
 
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/letter/repository/ElementRepository.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/repository/ElementRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ElementRepository extends JpaRepository<Element, Long>, ElementRepositoryCustom {
     Integer countByParticipant(Participant participant);
+
+    void deleteAllByLetterId(Long letterId);
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/letter/service/ElementDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/service/ElementDomainService.java
@@ -41,4 +41,8 @@ public class ElementDomainService {
         return elementRepository.findByLetterIdAndSequenceWithImage(letterId, sequence);
     }
 
+    @Transactional
+    public void deleteAllByLetterId(Long letterId) {
+        elementRepository.deleteAllByLetterId(letterId);
+    }
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/participant/repository/impl/ParticipantRepositoryCustom.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/participant/repository/impl/ParticipantRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.ittory.domain.participant.repository.impl;
 
 import com.ittory.domain.participant.domain.Participant;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +15,6 @@ public interface ParticipantRepositoryCustom {
     List<Participant> findAllParticipantsWithMember(Long letterId);
 
     Participant findByNickname(Long letterId, String nickname);
+
+    Integer countProgressByLetterId(Long letterId);
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/participant/repository/impl/ParticipantRepositoryImpl.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/participant/repository/impl/ParticipantRepositoryImpl.java
@@ -1,17 +1,18 @@
 package com.ittory.domain.participant.repository.impl;
 
 
+import com.ittory.domain.participant.domain.Participant;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
 import static com.ittory.domain.letter.domain.QLetter.letter;
 import static com.ittory.domain.member.domain.QMember.member;
 import static com.ittory.domain.participant.domain.QParticipant.participant;
 import static com.ittory.domain.participant.enums.ParticipantStatus.PROGRESS;
-
-import com.ittory.domain.participant.domain.Participant;
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
-import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class ParticipantRepositoryImpl implements ParticipantRepositoryCustom {
@@ -72,5 +73,14 @@ public class ParticipantRepositoryImpl implements ParticipantRepositoryCustom {
                         .and(participant.nickname.eq(nickname))
                 )
                 .fetchOne();
+    }
+
+    @Override
+    public Integer countProgressByLetterId(Long letterId) {
+        return jpaQueryFactory.selectFrom(participant)
+                .where(participant.letter.id.eq(letterId)
+                        .and(participant.participantStatus.eq(PROGRESS))
+                )
+                .fetch().size();
     }
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/participant/service/ParticipantDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/participant/service/ParticipantDomainService.java
@@ -1,14 +1,15 @@
 package com.ittory.domain.participant.service;
 
-import static com.ittory.domain.participant.enums.ParticipantStatus.EXITED;
-
 import com.ittory.domain.participant.domain.Participant;
 import com.ittory.domain.participant.exception.ParticipantException.ParticipantNotFoundException;
 import com.ittory.domain.participant.repository.ParticipantRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.ittory.domain.participant.enums.ParticipantStatus.EXITED;
 
 @Service
 @RequiredArgsConstructor
@@ -81,4 +82,8 @@ public class ParticipantDomainService {
         return participantCount < 5;
     }
 
+    @Transactional(readOnly = true)
+    public Integer countProgressByLetterId(Long letterId) {
+        return participantRepository.countProgressByLetterId(letterId);
+    }
 }


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- bugfix/RL1M-160 -> develop

### :memo:변경 사항
- 빈복횟수 설정 시 기존의 편지 요소는 삭제.
- 반복횟수가 (*참여자의 수)가 안되어 있던 현상 수정.
- 참여자 수 Count 시 모든 상태의 참여자를 Count하는 현상 수정 (with StartInfo)

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
<img width="653" alt="스크린샷 2024-10-30 오전 9 39 53" src="https://github.com/user-attachments/assets/06a5002e-f0a1-429f-a461-d61fd703554c">