### PR TITLE
fix : 편지 요소 생성 시 시작 Sequence 변경

### DIFF
--- a/ittory-domain/src/main/java/com/ittory/domain/letter/service/LetterDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/service/LetterDomainService.java
@@ -59,8 +59,8 @@ public class LetterDomainService {
         }
 
         Collections.shuffle(elementImages);
-        List<Element> elements = IntStream.range(0, totalCount)
-                .mapToObj(i -> Element.create(letter, null, elementImages.get(i), i, null))
+        List<Element> elements = IntStream.range(1, totalCount + 1)
+                .mapToObj(sequence -> Element.create(letter, null, elementImages.get(sequence), sequence, null))
                 .collect(Collectors.toList());
 
         letterElementRepository.saveAll(elements);


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-165 -> develop

### :memo:변경 사항
- 편지 요소 생성 시 시작 Sequence를 0 -> 1로 변경.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
<img width="562" alt="스크린샷 2024-11-06 오후 10 43 25" src="https://github.com/user-attachments/assets/19416fb7-6b5e-4a2d-8e7d-e569ac424da9">
