### PR TITLE
fix : 받은 편지함 로직 수정

### DIFF
--- a/ittory-api/src/main/java/com/ittory/api/member/controller/MemberController.java
+++ b/ittory-api/src/main/java/com/ittory/api/member/controller/MemberController.java
@@ -42,6 +42,7 @@ public class MemberController {
         return ResponseEntity.ok().body(response);
     }
 
+
     @Operation(summary = "회원 탈퇴", description = "(Authenticated) " +
             "탈퇴사유 = [ERROR, ANOTHER_ACCOUNT, BETTER_FUN, NOT_USE, ETC")
     @PostMapping("/withdraw")

--- a/ittory-domain/src/main/java/com/ittory/domain/member/domain/LetterBox.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/domain/LetterBox.java
@@ -29,11 +29,6 @@ public class LetterBox extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private LetterBoxType letterBoxType;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "receiver_id")
-    private Member receiver;
-
-
     public static LetterBox create(Member member, Letter letter, LetterBoxType type) {
         return LetterBox.builder()
                 .member(member)

--- a/ittory-domain/src/main/java/com/ittory/domain/member/domain/LetterBox.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/domain/LetterBox.java
@@ -29,6 +29,11 @@ public class LetterBox extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private LetterBoxType letterBoxType;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private Member receiver;
+
+
     public static LetterBox create(Member member, Letter letter, LetterBoxType type) {
         return LetterBox.builder()
                 .member(member)

--- a/ittory-domain/src/main/java/com/ittory/domain/member/repository/LetterBoxRepository.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/repository/LetterBoxRepository.java
@@ -4,6 +4,11 @@ import com.ittory.domain.member.domain.LetterBox;
 import com.ittory.domain.member.repository.impl.LetterBoxRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LetterBoxRepository extends JpaRepository<LetterBox, Long>, LetterBoxRepositoryCustom {
     void deleteByMemberIdAndLetterId(Long memberId, Long letterId);
+
+    List<LetterBox> findAllByReceiverId(Long receiverId); // receiverId 기준으로 LetterBox 조회
+
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/repository/LetterBoxRepository.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/repository/LetterBoxRepository.java
@@ -1,6 +1,7 @@
 package com.ittory.domain.member.repository;
 
 import com.ittory.domain.member.domain.LetterBox;
+import com.ittory.domain.member.enums.LetterBoxType;
 import com.ittory.domain.member.repository.impl.LetterBoxRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,6 +10,6 @@ import java.util.List;
 public interface LetterBoxRepository extends JpaRepository<LetterBox, Long>, LetterBoxRepositoryCustom {
     void deleteByMemberIdAndLetterId(Long memberId, Long letterId);
 
-    List<LetterBox> findAllByReceiverId(Long receiverId); // receiverId 기준으로 LetterBox 조회
+    List<LetterBox> findAllByMemberIdAndLetterBoxType(Long memberId, LetterBoxType letterBoxType);
 
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
@@ -5,6 +5,7 @@ import com.ittory.domain.member.domain.LetterBox;
 import com.ittory.domain.letter.domain.Letter;
 import com.ittory.domain.letter.repository.LetterRepository;
 import com.ittory.domain.member.domain.Member;
+import com.ittory.domain.member.enums.LetterBoxType;
 import com.ittory.domain.member.enums.MemberStatus;
 import com.ittory.domain.member.exception.MemberException.MemberNotFoundException;
 import com.ittory.domain.member.repository.LetterBoxRepository;
@@ -58,11 +59,12 @@ public class MemberDomainService {
 
     @Transactional(readOnly = true)
     public List<Letter> getReceivedLetters(Long memberId) {
-        return letterBoxRepository.findAllByReceiverId(memberId) // LetterBox 조회
+        return letterBoxRepository.findAllByMemberIdAndLetterBoxType(memberId, LetterBoxType.RECEIVE)
                 .stream()
-                .map(LetterBox::getLetter) // LetterBox에서 Letter 객체 추출
+                .map(LetterBox::getLetter)
                 .collect(Collectors.toList());
     }
+
 
     @Transactional
     public void withdrawMember(Member member) {

--- a/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
@@ -1,5 +1,7 @@
 package com.ittory.domain.member.service;
 
+
+import com.ittory.domain.member.domain.LetterBox;
 import com.ittory.domain.letter.domain.Letter;
 import com.ittory.domain.letter.repository.LetterRepository;
 import com.ittory.domain.member.domain.Member;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -55,7 +58,10 @@ public class MemberDomainService {
 
     @Transactional(readOnly = true)
     public List<Letter> getReceivedLetters(Long memberId) {
-        return letterRepository.findByReceiverIdOrderByDeliveryDateDesc(memberId);
+        return letterBoxRepository.findAllByReceiverId(memberId) // LetterBox 조회
+                .stream()
+                .map(LetterBox::getLetter) // LetterBox에서 Letter 객체 추출
+                .collect(Collectors.toList());
     }
 
     @Transactional


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-185 -> develop

### :memo:변경 사항
-  받은 편지함에서 letterbox.receiverId를 기준으로 조회했어야 하는데,
  [letter.receiver.id](http://letter.receiver.id/)를 기준으로 조회를 하고 있어서 
  지금 letterbox.letterId랑 letterbox.memberId를 기준으로 삭제가 되고 있는데.
  삭제가 원활하게 되지 않기 때문에,
  로직을 수정함.
------------------
domain/LetterBox에 receiver를 지우고,
LetterBoxType.Receive 로 받은편지 구분
LetterBox에 ReceiverId 대신 memberId와 LetterBoxType을 바탕으로 조회

### :heavy_plus_sign:추가 메모 (없다면 X)
- X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
<img width="1470" alt="스크린샷 2024-11-24 오후 8 03 55" src="https://github.com/user-attachments/assets/8824f579-d9a2-48a9-b34d-ea532ebde95f">