### PR TITLE
RL1M-197 feat : 편지 상세조회 타입 추가

### DIFF
--- a/ittory-api/src/main/java/com/ittory/api/letter/controller/LetterController.java
+++ b/ittory-api/src/main/java/com/ittory/api/letter/controller/LetterController.java
@@ -103,7 +103,7 @@ public class LetterController {
 
     @Operation(summary = "편지에 소속되어 있는 요소 조회", description = "(Authenticated, Pagination) size와 page가 없으면, 편지에 소속한 모든 요소를 조회")
     @GetMapping("/{letterId}/elements")
-    public ResponseEntity<LetterElementsResponse> getLetterDetails(@PathVariable Long letterId, Pageable pageable) {
+    public ResponseEntity<LetterElementsResponse> getLetterElements(@PathVariable Long letterId, Pageable pageable) {
         LetterElementsResponse response = letterElementsReadUseCase.execute(letterId, pageable);
         return ResponseEntity.ok().body(response);
     }

--- a/ittory-api/src/main/java/com/ittory/api/letter/dto/LetterElementResponse.java
+++ b/ittory-api/src/main/java/com/ittory/api/letter/dto/LetterElementResponse.java
@@ -1,27 +1,27 @@
 package com.ittory.api.letter.dto;
 
 import com.ittory.domain.letter.domain.Element;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class LetterElementResponse {
     private Long id;
+    private String nickname;
     private String coverImageUrl;
     private String content;
-
-    public LetterElementResponse(Long id, String coverImageUrl, String content) {
-        this.id = id;
-        this.coverImageUrl = coverImageUrl;
-        this.content = content;
-    }
+    private Integer sequence;
 
     public static LetterElementResponse from(Element letterElement) {
         return new LetterElementResponse(
                 letterElement.getId(),
+                letterElement.getParticipant().getNickname(),
                 letterElement.getElementImage().getUrl(),
-                letterElement.getContent()
+                letterElement.getContent(),
+                letterElement.getSequence()
         );
     }
 }

--- a/ittory-api/src/main/java/com/ittory/api/letter/usecase/LetterElementUseCase.java
+++ b/ittory-api/src/main/java/com/ittory/api/letter/usecase/LetterElementUseCase.java
@@ -18,6 +18,7 @@ public class LetterElementUseCase {
     public LetterElementResponse execute(Long letterElementId, LetterElementRequest request) {
         Element element = elementDomainService.findById(letterElementId);
         letterDomainService.updateLetterElement(letterElementId, request.getContent());
-        return new LetterElementResponse(letterElementId, element.getElementImage().getUrl(), request.getContent());
+        return new LetterElementResponse(letterElementId, element.getParticipant().getNickname(),
+                element.getElementImage().getUrl(), request.getContent(), element.getSequence());
     }
 }


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-197 -> develop

### :memo:변경 사항
- 편지 상세조회에 구서용소 추가.
    - nickname 추가.
    - sequence 추가.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
<img width="909" alt="스크린샷 2024-11-30 오후 12 45 43" src="https://github.com/user-attachments/assets/c7c2e072-ef08-4cba-b8d8-95bb58ce54f6">
