### PR TITLE
Feature/rl1 m 230

### DIFF
--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
@@ -74,15 +74,8 @@ public class AuthController {
 
     @Operation(summary = "로그아웃", description = "(Authenticated) RefreshToken 삭제.")
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
-                                       @CurrentMemberId Long memberId, HttpServletResponse response) {
+    public ResponseEntity<Void> logout(@CurrentMemberId Long memberId) {
         authService.logout(memberId);
-
-        // TODO: 프론트 수정 후 삭제 로직 - by junker 25.03.12.
-        if (refreshToken != null) {
-            ResponseCookie refreshTokenCookie = cookieProvider.createExpiredResponseCookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
-            response.addHeader("Set-Cookie", refreshTokenCookie.toString());
-        }
         return ResponseEntity.ok().build();
     }
 

--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
@@ -42,7 +42,15 @@ public class AuthController {
     @PostMapping("/login/kakao")
     public ResponseEntity<AuthTokenResponse> loginByKaKao(@Valid @RequestBody KaKaoLoginRequest request,
                                                           HttpServletResponse response) {
-        AuthTokenResponse tokenResponse = kaKaoLoginService.execute(request.getAccessToken());
+        // TODO: 프론트 수정 후 다음 로직으로 변경할 예정 - by junker 25.03.19.
+//        AuthTokenResponse tokenResponse = kaKaoLoginService.loginOrRegister(request.getAuthorizationCode());
+        AuthTokenResponse tokenResponse;
+        if (request.getAccessToken() != null) {
+            tokenResponse = kaKaoLoginService.loginOrRegister(request.getAccessToken(), false);
+        } else {
+            tokenResponse = kaKaoLoginService.loginOrRegister(request.getAuthorizationCode(), true);
+        }
+
 
         log.info("Login with {} in {}", tokenResponse.getAccessToken(), LocalDateTime.now());
         ResponseCookie refreshTokenCookie = cookieProvider.createResponseCookie(REFRESH_TOKEN_COOKIE_NAME, tokenResponse.getRefreshToken(), REFRESH_TOKEN_EXPIRATION_TIME);

--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -53,13 +54,13 @@ public class AuthController {
     @Operation(summary = "Access Token 갱신", description = "잇토리 AccessToken, 잇토리 RefreshToken 필요.")
     @PostMapping("/refresh")
     public ResponseEntity<TokenRefreshResponse> refreshMemberToken(@CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
-                                                                   @Valid @RequestBody TokenRefreshRequest request) {
+                                                                   @Nullable @RequestBody TokenRefreshRequest request) {
 
         // TODO: 프론트 수정 후 삭제 로직 - by junker 25.03.12.
         if (refreshToken == null) {
             refreshToken = request.getRefreshToken();
         }
-        TokenRefreshResponse tokenResponse = authService.renewToken(request.getAccessToken(), refreshToken);
+        TokenRefreshResponse tokenResponse = authService.renewToken(refreshToken);
         return ResponseEntity.ok().body(tokenResponse);
     }
 
@@ -68,7 +69,7 @@ public class AuthController {
     public ResponseEntity<Void> logout(@CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
                                        @CurrentMemberId Long memberId, HttpServletResponse response) {
         authService.logout(memberId);
-        
+
         // TODO: 프론트 수정 후 삭제 로직 - by junker 25.03.12.
         if (refreshToken != null) {
             ResponseCookie refreshTokenCookie = cookieProvider.createExpiredResponseCookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);

--- a/ittory-api/src/main/java/com/ittory/api/auth/dto/KaKaoLoginRequest.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/dto/KaKaoLoginRequest.java
@@ -1,19 +1,23 @@
 package com.ittory.api.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class KaKaoLoginRequest {
 
-    @Schema(description = "카카오 엑세스 토큰")
-    @NotNull
+    @Schema(description = "==삭제 예정== 카카오 엑세스 토큰")
+    @Nullable
     private String accessToken;
+
+    @Schema(description = "카카오 인가 코드")
+    @Nullable
+    private String authorizationCode;
 
 }

--- a/ittory-api/src/main/java/com/ittory/api/auth/dto/TokenRefreshRequest.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/dto/TokenRefreshRequest.java
@@ -1,6 +1,5 @@
 package com.ittory.api.auth.dto;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +9,7 @@ import org.springframework.lang.Nullable;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TokenRefreshRequest {
 
-    @NotNull
+    @Nullable
     private String accessToken;
     @Nullable
     private String refreshToken;

--- a/ittory-api/src/main/java/com/ittory/api/auth/exception/AuthErrorCode.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/exception/AuthErrorCode.java
@@ -1,18 +1,19 @@
 package com.ittory.api.auth.exception;
 
-import static com.ittory.common.exception.ErrorStatus.BAD_REQUEST;
-import static com.ittory.common.exception.ErrorStatus.FORBIDDEN;
-
 import com.ittory.common.exception.ErrorStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import static com.ittory.common.exception.ErrorStatus.BAD_REQUEST;
+import static com.ittory.common.exception.ErrorStatus.FORBIDDEN;
 
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode {
 
     NO_REFRESH_TOKEN(FORBIDDEN, "5000", "로그아웃된 사용자입니다."),
-    REFRESH_TOKEN_NOT_MATCH(BAD_REQUEST, "5001", "Refresh Token이 일치하지 않습니다.");
+    REFRESH_TOKEN_NOT_MATCH(BAD_REQUEST, "5001", "Refresh Token이 일치하지 않습니다."),
+    NOT_A_REFRESH_TOKEN_TYPE(BAD_REQUEST, "5002", "Refresh Token이 아닙니다.");
 
     private final ErrorStatus status;
     private final String code;

--- a/ittory-api/src/main/java/com/ittory/api/auth/exception/AuthException.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/exception/AuthException.java
@@ -1,11 +1,10 @@
 package com.ittory.api.auth.exception;
 
-import static com.ittory.api.auth.exception.AuthErrorCode.NO_REFRESH_TOKEN;
-import static com.ittory.api.auth.exception.AuthErrorCode.REFRESH_TOKEN_NOT_MATCH;
-
 import com.ittory.common.exception.ErrorInfo;
 import com.ittory.common.exception.ErrorStatus;
 import com.ittory.common.exception.GlobalException;
+
+import static com.ittory.api.auth.exception.AuthErrorCode.*;
 
 public class AuthException extends GlobalException {
 
@@ -24,6 +23,14 @@ public class AuthException extends GlobalException {
         public RefreshTokenNotMatchException(String refreshToken) {
             super(REFRESH_TOKEN_NOT_MATCH.getStatus(),
                     new ErrorInfo<>(REFRESH_TOKEN_NOT_MATCH.getCode(), REFRESH_TOKEN_NOT_MATCH.getMessage(),
+                            refreshToken));
+        }
+    }
+
+    public static class NotARefreshTokenTypeException extends AuthException {
+        public NotARefreshTokenTypeException(String refreshToken) {
+            super(NOT_A_REFRESH_TOKEN_TYPE.getStatus(),
+                    new ErrorInfo<>(NOT_A_REFRESH_TOKEN_TYPE.getCode(), NOT_A_REFRESH_TOKEN_TYPE.getMessage(),
                             refreshToken));
         }
     }

--- a/ittory-api/src/main/java/com/ittory/api/auth/service/AuthService.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/service/AuthService.java
@@ -23,19 +23,19 @@ public class AuthService {
         memberDomainService.changeRefreshToken(member, null);
     }
 
-    public TokenRefreshResponse renewToken(String accessToken, String refreshToken) {
-        Long memberId = jwtProvider.getSubByExpiredToken(accessToken);
-        Member member = memberDomainService.findMemberById(memberId);
+    public TokenRefreshResponse renewToken(String refreshToken) {
 
-        if (member.getRefreshToken() == null) {
+        if (!jwtProvider.isRefreshToken(refreshToken)) {
+            throw new AuthException.NotARefreshTokenTypeException(refreshToken);
+        }
+
+        Member member = memberDomainService.findMemberByRefreshToken(refreshToken);
+
+        if (member == null) {
             throw new AuthException.NoRefreshTokenException();
         }
 
-        if (!member.getRefreshToken().equals(refreshToken)) {
-            throw new AuthException.RefreshTokenNotMatchException(refreshToken);
-        }
-
-        String newCreatedAccessToken = createdAccessToken(memberId);
+        String newCreatedAccessToken = createdAccessToken(member.getId());
 
         return TokenRefreshResponse.of(newCreatedAccessToken);
 

--- a/ittory-api/src/main/java/com/ittory/api/auth/service/KaKaoLoginService.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/service/KaKaoLoginService.java
@@ -6,6 +6,7 @@ import com.ittory.domain.member.domain.Member;
 import com.ittory.domain.member.service.MemberDomainService;
 import com.ittory.infra.discord.DiscordWebHookService;
 import com.ittory.infra.oauth.kakao.KaKaoPlatformClient;
+import com.ittory.infra.oauth.kakao.dto.KaKaoTokenResponse;
 import com.ittory.infra.oauth.kakao.dto.MemberInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,14 @@ public class KaKaoLoginService {
     private final MemberDomainService memberDomainService;
     private final DiscordWebHookService discordWebHookService;
 
-    public AuthTokenResponse execute(String accessToken) {
+    public AuthTokenResponse loginOrRegister(String authorizationCode, boolean isCode) {
+        String accessToken = authorizationCode;
+        if (isCode) {
+            KaKaoTokenResponse tokenResponse = kaKaoPlatformClient.getKakaoAccessToken(authorizationCode);
+            System.out.println("====== 11");
+            accessToken = tokenResponse.getAccessToken();
+            System.out.println("====== 22");
+        }
         MemberInfo memberInfo = kaKaoPlatformClient.getMemberInfo(accessToken);
         Member member = memberDomainService.findMemberBySocialId(memberInfo.getSocialId());
 

--- a/ittory-api/src/main/java/com/ittory/api/auth/util/CookieProvider.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/util/CookieProvider.java
@@ -14,12 +14,4 @@ public class CookieProvider {
                 .build();
     }
 
-    public ResponseCookie createExpiredResponseCookie(String cookieName, String value) {
-        return ResponseCookie.from(cookieName, value)
-                .httpOnly(true)
-                .path("/")
-                .maxAge(0) // 바로 만료
-                .build();
-    }
-
 }

--- a/ittory-api/src/test/java/com/ittory/api/auth/service/KaKaoLoginServiceTest.java
+++ b/ittory-api/src/test/java/com/ittory/api/auth/service/KaKaoLoginServiceTest.java
@@ -1,6 +1,5 @@
 package com.ittory.api.auth.service;
 
-import com.ittory.api.auth.dto.AuthTokenResponse;
 import com.ittory.common.jwt.JwtProvider;
 import com.ittory.domain.member.domain.Member;
 import com.ittory.domain.member.enums.MemberStatus;
@@ -9,7 +8,7 @@ import com.ittory.infra.discord.DiscordWebHookService;
 import com.ittory.infra.oauth.kakao.KaKaoPlatformClient;
 import com.ittory.infra.oauth.kakao.dto.KaKaoTokenResponse;
 import com.ittory.infra.oauth.kakao.dto.MemberInfo;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -38,6 +37,7 @@ public class KaKaoLoginServiceTest {
 
     //Member.create(1L, "test man", null)
     @Test
+    @Disabled("프론트 로직 변경 후 활성화 -by. 준커 25.03.19")
     void executeTest_Save() {
         //given
         String kakaoCode = "kakao_code";
@@ -51,7 +51,7 @@ public class KaKaoLoginServiceTest {
                 .refreshToken(null)
                 .build();
 
-        when(kaKaoPlatformClient.getToken(any(String.class))).thenReturn(new KaKaoTokenResponse(kakaoAccessToken));
+        when(kaKaoPlatformClient.getKakaoAccessToken(any(String.class))).thenReturn(new KaKaoTokenResponse(kakaoAccessToken));
         when(kaKaoPlatformClient.getMemberInfo(any(String.class))).thenReturn(new MemberInfo(1L, "test man", null));
         when(memberDomainService.findMemberBySocialId(any(Long.class))).thenReturn(null);
         when(memberDomainService.saveMember(1L, "test man", null)).thenReturn(member);
@@ -60,13 +60,14 @@ public class KaKaoLoginServiceTest {
         doNothing().when(discordWebHookService).sendSingupMessage(any(Member.class));
 
         //when
-        AuthTokenResponse execute = kaKaoLoginService.execute(kakaoCode);
-
-        Assertions.assertThat(execute.getAccessToken()).isEqualTo("access.token");
-        Assertions.assertThat(execute.getRefreshToken()).isEqualTo("refresh.token");
+//        AuthTokenResponse execute = kaKaoLoginService.loginOrRegister(kakaoCode);
+//
+//        Assertions.assertThat(execute.getAccessToken()).isEqualTo("access.token");
+//        Assertions.assertThat(execute.getRefreshToken()).isEqualTo("refresh.token");
     }
 
     @Test
+    @Disabled("프론트 로직 변경 후 활성화 -by. 준커 25.03.19")
     void executeTest_Find() {
         //given
         String kakaoCode = "kakao_code";
@@ -80,17 +81,17 @@ public class KaKaoLoginServiceTest {
                 .refreshToken(null)
                 .build();
 
-        when(kaKaoPlatformClient.getToken(any(String.class))).thenReturn(new KaKaoTokenResponse(kakaoAccessToken));
+        when(kaKaoPlatformClient.getKakaoAccessToken(any(String.class))).thenReturn(new KaKaoTokenResponse(kakaoAccessToken));
         when(kaKaoPlatformClient.getMemberInfo(any(String.class))).thenReturn(new MemberInfo(1L, "test man", null));
         when(memberDomainService.findMemberBySocialId(any(Long.class))).thenReturn(member);
         when(jwtProvider.createAccessToken(any(Long.class), any(String.class))).thenReturn("access.token");
         when(jwtProvider.createRefreshToken(any(Long.class))).thenReturn("refresh.token");
 
         //when
-        AuthTokenResponse execute = kaKaoLoginService.execute(kakaoCode);
-
-        Assertions.assertThat(execute.getAccessToken()).isEqualTo("access.token");
-        Assertions.assertThat(execute.getRefreshToken()).isEqualTo("refresh.token");
+//        AuthTokenResponse execute = kaKaoLoginService.loginOrRegister(kakaoCode);
+//
+//        Assertions.assertThat(execute.getAccessToken()).isEqualTo("access.token");
+//        Assertions.assertThat(execute.getRefreshToken()).isEqualTo("refresh.token");
     }
 
 }

--- a/ittory-common/src/main/java/com/ittory/common/jwt/JwtProvider.java
+++ b/ittory-common/src/main/java/com/ittory/common/jwt/JwtProvider.java
@@ -111,4 +111,17 @@ public class JwtProvider {
         }
     }
 
+    public boolean isRefreshToken(String refreshToken) {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            String[] splitToken = refreshToken.split("\\.");
+            String base64EncodedBody = splitToken[1];
+            String body = new String(Base64.getUrlDecoder().decode(base64EncodedBody));
+            JsonNode payloadJson = objectMapper.readTree(body);
+            return payloadJson.get("type").asText().equals("REFRESH");
+        } catch (Exception exception) {
+            throw new InvalidateTokenException(refreshToken);
+        }
+    }
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/repository/MemberRepository.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/repository/MemberRepository.java
@@ -11,4 +11,7 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
     Optional<Member> findBySocialId(Long socialId);
 
     long countByMemberStatus(MemberStatus memberStatus);
+
+    Optional<Member> findByRefreshToken(String refreshToken);
+
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
@@ -77,4 +77,9 @@ public class MemberDomainService {
         Integer participationLetterCount = letterBoxRepository.countParticipationLetterByMemberId(memberId);
         return participationLetterCount > 0;
     }
+
+    @Transactional(readOnly = true)
+    public Member findMemberByRefreshToken(String refreshToken) {
+        return memberDomainRepository.findByRefreshToken(refreshToken).orElse(null);
+    }
 }

--- a/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/KaKaoPlatformClient.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/KaKaoPlatformClient.java
@@ -1,8 +1,5 @@
 package com.ittory.infra.oauth.kakao;
 
-import static com.ittory.common.constant.TokenConstant.ACCESS_TOKEN_HEADER;
-import static com.ittory.common.constant.TokenConstant.TOKEN_TYPER;
-
 import com.ittory.infra.oauth.exception.OAuthException.OAuthServerException;
 import com.ittory.infra.oauth.exception.OAuthException.SocialMemberNoInfoException;
 import com.ittory.infra.oauth.exception.OAuthException.UnauthorizedTokenException;
@@ -17,6 +14,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+
+import static com.ittory.common.constant.TokenConstant.ACCESS_TOKEN_HEADER;
+import static com.ittory.common.constant.TokenConstant.TOKEN_TYPER;
 
 @Component
 public class KaKaoPlatformClient {
@@ -35,7 +35,7 @@ public class KaKaoPlatformClient {
     @Value("${kakao.clientSecret}")
     private String CLIENT_SECRET;
 
-    public KaKaoTokenResponse getToken(String code) {
+    public KaKaoTokenResponse getKakaoAccessToken(String authorizationCode) {
         WebClient client = WebClient.create();
 
         Mono<KaKaoTokenResponse> kaKaoTokenResponseMono = client.post()
@@ -44,12 +44,12 @@ public class KaKaoPlatformClient {
                 .body(BodyInserters.fromFormData("grant_type", GRANT_TYPE)
                         .with("client_id", CLIENT_ID)
                         .with("redirect_uri", REDIRECT_URI)
-                        .with("code", code)
+                        .with("code", authorizationCode)
                         .with("client_secret", CLIENT_SECRET)
                 )
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError,
-                        response -> Mono.error(new UnauthorizedTokenException(code)))
+                        response -> Mono.error(new UnauthorizedTokenException(authorizationCode)))
                 .onStatus(HttpStatusCode::is5xxServerError,
                         response -> Mono.error(new OAuthServerException(ACCESS_TOKEN_URL)))
                 .bodyToMono(KaKaoTokenResponse.class);

--- a/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/KaKaoTokenResponse.java
+++ b/ittory-infra/src/main/java/com/ittory/infra/oauth/kakao/dto/KaKaoTokenResponse.java
@@ -3,9 +3,11 @@ package com.ittory.infra.oauth.kakao.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class KaKaoTokenResponse {
 
     @JsonProperty("access_token")

--- a/ittory-infra/src/main/resources/infra.yml
+++ b/ittory-infra/src/main/resources/infra.yml
@@ -13,11 +13,6 @@ aws:
     bucketName: ${S3_BUCKET_NAME}
     baseUrl: ${S3_BASE_URL}
 
-kakao:
-  clientId: ${KAKAO_CLIENT_ID}
-  redirectUri: ${KAKAO_REDIRECT_URI}
-  clientSecret: ${KAKAO_CLIENT_SECRET}
-
 discord:
   webhook:
     signup: null
@@ -31,17 +26,33 @@ spring:
     activate:
       on-profile: local
 
+kakao:
+  clientId: ${KAKAO_CLIENT_ID}
+  redirectUri: ${KAKAO_LOCAL_REDIRECT_URI}
+  clientSecret: ${KAKAO_CLIENT_SECRET}
+
 ---
 spring:
   config:
     activate:
       on-profile: dev
 
+kakao:
+  clientId: ${KAKAO_CLIENT_ID}
+  redirectUri: ${KAKAO_DEV_REDIRECT_URI}
+  clientSecret: ${KAKAO_CLIENT_SECRET}
+
 ---
 spring:
   config:
     activate:
       on-profile: prod
+
+kakao:
+  clientId: ${KAKAO_CLIENT_ID}
+  redirectUri: ${KAKAO_PROD_REDIRECT_URI}
+  clientSecret: ${KAKAO_CLIENT_SECRET}
+
 discord:
   webhook:
     signup: ${SIGNUP_DISCORD_WEBHOOK_URL}


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [X] 기능 삭제
- [X] 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-230 -> develop

### :memo:변경 사항
- Token Refresh 로직 변경
    - AccessToken + RefreshToken -> RefreshToken.
- 카카오 로그인 방식 변경
    - AccessToken을 받음 -> 인가 코드를 받음.
- 로그아웃 로직 변경
    - 만료된 쿠키 전달 -> 만료된 쿠키를 전달하지 않음.
- AccessToken 만료기간 변경
    - 12시간 -> 1시간

### :heavy_plus_sign:추가 메모 (없다면 X)
- 변경된 로직에 연동성을 위해서 기존 로직이 남아있음. 프론트 반영이후 삭제 예정.

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
<img width="771" alt="스크린샷 2025-03-19 오후 5 53 35" src="https://github.com/user-attachments/assets/78cf6ac0-0a9f-44aa-a661-3f32d276c095" />
