### PR TITLE
RL1M-270 feat : 테스트 로그인 기능 추가

### DIFF
--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthTestController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthTestController.java
@@ -1,0 +1,51 @@
+package com.ittory.api.auth.controller;
+
+import com.ittory.api.auth.dto.AuthTokenResponse;
+import com.ittory.api.auth.dto.IdLoginRequest;
+import com.ittory.api.auth.service.IdLoginService;
+import com.ittory.api.auth.util.CookieProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@Profile("dev")
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthTestController {
+
+    private final IdLoginService idLoginService;
+
+    private final CookieProvider cookieProvider;
+
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
+    @Value("${spring.jwt.token.refresh-expiration-time}")
+    private Long REFRESH_TOKEN_EXPIRATION_TIME;
+
+    @Operation(summary = "아이디로 로그인", description = "테스트를 위한 로그인")
+    @PostMapping("/login/id")
+    public ResponseEntity<AuthTokenResponse> loginByKaKao(@Valid @RequestBody IdLoginRequest request,
+                                                          HttpServletResponse response) {
+        AuthTokenResponse tokenResponse = idLoginService.login(request.getLoginId());
+
+        log.info("Login with {} in {}", tokenResponse.getAccessToken(), LocalDateTime.now());
+        ResponseCookie refreshTokenCookie = cookieProvider.createResponseCookie(REFRESH_TOKEN_COOKIE_NAME, tokenResponse.getRefreshToken(), REFRESH_TOKEN_EXPIRATION_TIME);
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+
+        return ResponseEntity.ok().body(tokenResponse);
+    }
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthTestController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthTestController.java
@@ -38,8 +38,8 @@ public class AuthTestController {
 
     @Operation(summary = "아이디로 로그인", description = "테스트를 위한 로그인")
     @PostMapping("/login/id")
-    public ResponseEntity<AuthTokenResponse> loginByKaKao(@Valid @RequestBody IdLoginRequest request,
-                                                          HttpServletResponse response) {
+    public ResponseEntity<AuthTokenResponse> loginByLoginId(@Valid @RequestBody IdLoginRequest request,
+                                                            HttpServletResponse response) {
         AuthTokenResponse tokenResponse = idLoginService.login(request.getLoginId());
 
         log.info("Login with {} in {}", tokenResponse.getAccessToken(), LocalDateTime.now());

--- a/ittory-api/src/main/java/com/ittory/api/auth/dto/IdLoginRequest.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/dto/IdLoginRequest.java
@@ -1,0 +1,17 @@
+package com.ittory.api.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class IdLoginRequest {
+
+    @Schema(description = "로그인 ID")
+    private String loginId;
+
+}

--- a/ittory-api/src/main/java/com/ittory/api/auth/service/IdLoginService.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/service/IdLoginService.java
@@ -1,0 +1,32 @@
+package com.ittory.api.auth.service;
+
+import com.ittory.api.auth.dto.AuthTokenResponse;
+import com.ittory.common.jwt.JwtProvider;
+import com.ittory.domain.member.domain.Member;
+import com.ittory.domain.member.service.MemberDomainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.ittory.common.constant.MemberRole.MEMBER;
+
+@Service
+@RequiredArgsConstructor
+public class IdLoginService {
+
+    private final JwtProvider jwtProvider;
+    private final MemberDomainService memberDomainService;
+
+    @Transactional
+    public AuthTokenResponse login(String loginId) {
+        Member member = memberDomainService.findMemberByLoginId(loginId);
+        return generateMemberToken(member);
+    }
+
+    private AuthTokenResponse generateMemberToken(Member member) {
+        String memberAccessToken = jwtProvider.createAccessToken(member.getId(), MEMBER);
+        String memberRefreshToken = jwtProvider.createRefreshToken(member.getId());
+        memberDomainService.changeRefreshToken(member, memberRefreshToken);
+        return AuthTokenResponse.of(memberAccessToken, memberRefreshToken);
+    }
+}

--- a/ittory-domain/src/main/java/com/ittory/domain/member/domain/Member.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/domain/Member.java
@@ -2,18 +2,8 @@ package com.ittory.domain.member.domain;
 
 import com.ittory.domain.common.BaseEntity;
 import com.ittory.domain.member.enums.MemberStatus;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity(name = "member")
 @Getter
@@ -37,6 +27,8 @@ public class Member extends BaseEntity {
     private MemberStatus memberStatus;
 
     private String refreshToken;
+
+    private String loginId;
 
 
     public static Member create(Long socialId, String name, String profileImage) {

--- a/ittory-domain/src/main/java/com/ittory/domain/member/exception/MemberException.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/exception/MemberException.java
@@ -1,11 +1,11 @@
 package com.ittory.domain.member.exception;
 
-import static com.ittory.domain.member.exception.MemberErrorCode.LETTER_BOX_ALREADY_STORED;
-import static com.ittory.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND_ERROR;
-
 import com.ittory.common.exception.ErrorInfo;
 import com.ittory.common.exception.ErrorStatus;
 import com.ittory.common.exception.GlobalException;
+
+import static com.ittory.domain.member.exception.MemberErrorCode.LETTER_BOX_ALREADY_STORED;
+import static com.ittory.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND_ERROR;
 
 public class MemberException extends GlobalException {
 
@@ -18,6 +18,12 @@ public class MemberException extends GlobalException {
             super(MEMBER_NOT_FOUND_ERROR.getStatus(),
                     new ErrorInfo<>(MEMBER_NOT_FOUND_ERROR.getCode(), MEMBER_NOT_FOUND_ERROR.getMessage(), memberId));
         }
+
+        public MemberNotFoundException(String loginId) {
+            super(MEMBER_NOT_FOUND_ERROR.getStatus(),
+                    new ErrorInfo<>(MEMBER_NOT_FOUND_ERROR.getCode(), MEMBER_NOT_FOUND_ERROR.getMessage(), loginId));
+        }
+
     }
 
     public static class LetterBoxAlreadyStoredException extends MemberException {

--- a/ittory-domain/src/main/java/com/ittory/domain/member/repository/impl/MemberRepositoryCustom.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/repository/impl/MemberRepositoryCustom.java
@@ -1,7 +1,12 @@
 package com.ittory.domain.member.repository.impl;
 
+import com.ittory.domain.member.domain.Member;
+
 import java.time.LocalDate;
+import java.util.Optional;
 
 public interface MemberRepositoryCustom {
     long countSignUpByDate(LocalDate date);
+
+    Optional<Member> findByLoginId(String loginId);
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/repository/impl/MemberRepositoryImpl.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/repository/impl/MemberRepositoryImpl.java
@@ -1,10 +1,12 @@
 package com.ittory.domain.member.repository.impl;
 
+import com.ittory.domain.member.domain.Member;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static com.ittory.domain.member.domain.QMember.member;
 
@@ -22,4 +24,12 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .size();
     }
 
+    @Override
+    public Optional<Member> findByLoginId(String loginId) {
+        Member content = jpaQueryFactory.selectFrom(member)
+                .where(member.loginId.eq(loginId))
+                .fetchOne();
+
+        return Optional.ofNullable(content);
+    }
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
@@ -82,4 +82,8 @@ public class MemberDomainService {
     public Member findMemberByRefreshToken(String refreshToken) {
         return memberDomainRepository.findByRefreshToken(refreshToken).orElse(null);
     }
+
+    public Member findMemberByLoginId(String loginId) {
+        return memberDomainRepository.findByLoginId(loginId).orElseThrow(() -> new MemberNotFoundException(loginId));
+    }
 }


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-270 -> develop

### :memo:변경 사항
- 아이디를 이용해서 테스트로 로그인하는 기능 추가.
- Dev 서버에서만 작동하게 설정.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
=API=
<img width="695" alt="스크린샷 2025-04-19 오후 11 16 14" src="https://github.com/user-attachments/assets/bb5086b5-527e-43e0-9e89-ccceb561e0cd" />

=Socket=
<img width="669" alt="스크린샷 2025-04-19 오후 11 17 01" src="https://github.com/user-attachments/assets/40d6f78e-415f-450d-9f8d-da6c8710cdec" />
