### PR TITLE
Bugfix/RL1M-289

### DIFF
--- a/ittory-domain/src/main/java/com/ittory/domain/participant/repository/impl/ParticipantRepositoryImpl.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/participant/repository/impl/ParticipantRepositoryImpl.java
@@ -92,7 +92,7 @@ public class ParticipantRepositoryImpl implements ParticipantRepositoryCustom {
         return jpaQueryFactory.selectFrom(participant)
                 .leftJoin(participant.letter, letter).fetchJoin()
                 .where(letter.id.eq(letterId))
-                .orderBy(participant.createdAt.asc())
+                .orderBy(participant.updatedAt.asc())
                 .limit(1)
                 .fetchOne();
     }

--- a/ittory-socket/src/main/java/com/ittory/socket/SocketApplication.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/SocketApplication.java
@@ -4,8 +4,10 @@ import com.ittory.domain.config.JpaConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Import(JpaConfig.class)
+@EnableJpaAuditing
 @SpringBootApplication
 public class SocketApplication {
 

--- a/ittory-socket/src/main/java/com/ittory/socket/common/exception/WebSocketExceptionAdvice.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/common/exception/WebSocketExceptionAdvice.java
@@ -4,8 +4,13 @@ import com.ittory.common.exception.GlobalException;
 import com.ittory.infra.discord.WebHookService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 @ControllerAdvice
 @Slf4j
@@ -18,28 +23,62 @@ public class WebSocketExceptionAdvice {
     private final WebHookService webHookService;
 
     @MessageExceptionHandler(GlobalException.class)
-    public void handleWebSocketGlobalException(GlobalException exception) {
+    public void handleWebSocketGlobalException(GlobalException exception, Message<?> message) {
         log.error(LOG_CODE_FORMAT, "GlobalException", exception.getClass().getName(),
                 exception.getErrorInfo().getCode(), exception.getMessage());
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        String destination = accessor.getDestination();
+        String messageBody = null;
+        Object payload = message.getPayload();
+        if (payload instanceof byte[]) {
+            messageBody = new String((byte[]) payload, StandardCharsets.UTF_8);
+        }
+        Object memberId = accessor.getSessionAttributes().get("member_id");
+
         StringBuilder sb = new StringBuilder();
-        StringBuilder message = sb.append("======= Socket Error =======").append("\n")
+        StringBuilder webHookMessage = sb.append("======= Socket Error =======").append("\n")
                 .append(exception.getClass().getName())
                 .append(" : ")
                 .append(exception.getErrorInfo().getCode())
                 .append(" -> ")
-                .append(exception.getMessage());
-        webHookService.sendErrorLog(message.toString());
+                .append(exception.getMessage()).append("\n\n")
+                .append("== Stack Trace ==").append("\n")
+                .append(Arrays.toString(exception.getStackTrace())).append("\n\n")
+                .append("== Request Trace ==").append("\n")
+                .append("Destination: ").append(destination).append("\n")
+                .append("Message Content: ").append(messageBody).append("\n")
+                .append("MemberId: ").append(memberId.toString()).append("\n");
+
+        webHookService.sendErrorLog(webHookMessage.toString());
     }
 
     @MessageExceptionHandler(RuntimeException.class)
-    public void handleWebSocketException(Exception exception) {
+    public void handleWebSocketException(Exception exception, Message<?> message) {
         log.error(LOG_FORMAT, "RuntimeException", exception.getClass().getName(), exception.getMessage());
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        String destination = accessor.getDestination();
+        String messageBody = null;
+        Object payload = message.getPayload();
+        if (payload instanceof byte[]) {
+            messageBody = new String((byte[]) payload, StandardCharsets.UTF_8);
+        }
+        Object memberId = accessor.getSessionAttributes().get("member_id");
+
         StringBuilder sb = new StringBuilder();
-        StringBuilder message = sb.append("======= Socket Error =======").append("\n")
+        StringBuilder webHookMessage = sb.append("======= Socket Error =======").append("\n")
                 .append(exception.getClass().getName())
                 .append(" -> ")
-                .append(exception.getMessage());
-        webHookService.sendErrorLog(message.toString());
+                .append(exception.getMessage()).append("\n\n")
+                .append("== Stack Trace ==").append("\n")
+                .append(Arrays.toString(exception.getStackTrace())).append("\n\n")
+                .append("== Request Trace ==").append("\n")
+                .append("Destination: ").append(destination).append("\n")
+                .append("Message Content: ").append(messageBody).append("\n")
+                .append("MemberId: ").append(memberId.toString()).append("\n");
+
+        webHookService.sendErrorLog(webHookMessage.toString());
     }
 
 }


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- bugfix/RL1M-289 -> develop

### :memo:변경 사항
- isManager 값이 true로만 들어오던 버그 수정.
- Socket 모듈에서 예외 발생시, 웹훅 메세지에 Request 정보와 Stack Trace 추가.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
= API =
<img width="794" alt="스크린샷 2025-04-30 오후 4 54 48" src="https://github.com/user-attachments/assets/0f53c2df-1286-4a3f-8885-10781c4e8dcc" />

= Socket =
<img width="767" alt="스크린샷 2025-04-30 오후 4 55 59" src="https://github.com/user-attachments/assets/d59932a0-b220-4c66-902b-087077458894" />
