### PR TITLE
RL1M-297 feat: 테스트 계정 목록 조회

### DIFF
--- a/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthTestController.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/controller/AuthTestController.java
@@ -4,6 +4,7 @@ import com.ittory.api.auth.dto.AuthTokenResponse;
 import com.ittory.api.auth.dto.IdLoginRequest;
 import com.ittory.api.auth.service.IdLoginService;
 import com.ittory.api.auth.util.CookieProvider;
+import com.ittory.api.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -13,12 +14,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Profile("dev")
 @Slf4j
@@ -47,5 +46,12 @@ public class AuthTestController {
         response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
         return ResponseEntity.ok().body(tokenResponse);
+    }
+
+    @Operation(summary = "테스트 계정 목록 조회", description = "테스트를 위한 계정 목록 조회")
+    @GetMapping("/login/id")
+    public ResponseEntity<List<String>> findAllIdAuth() {
+        List<String> idAuths = idLoginService.findAllIdAuth();
+        return ResponseEntity.ok().body(idAuths);
     }
 }

--- a/ittory-api/src/main/java/com/ittory/api/auth/service/IdLoginService.java
+++ b/ittory-api/src/main/java/com/ittory/api/auth/service/IdLoginService.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static com.ittory.common.constant.MemberRole.MEMBER;
 
 @Service
@@ -28,5 +30,12 @@ public class IdLoginService {
         String memberRefreshToken = jwtProvider.createRefreshToken(member.getId());
         memberDomainService.changeRefreshToken(member, memberRefreshToken);
         return AuthTokenResponse.of(memberAccessToken, memberRefreshToken);
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> findAllIdAuth() {
+        return memberDomainService.findAllIdMember().stream()
+                .map(Member::getLoginId)
+                .toList();
     }
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/repository/impl/MemberRepositoryCustom.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/repository/impl/MemberRepositoryCustom.java
@@ -3,10 +3,13 @@ package com.ittory.domain.member.repository.impl;
 import com.ittory.domain.member.domain.Member;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepositoryCustom {
     long countSignUpByDate(LocalDate date);
 
     Optional<Member> findByLoginId(String loginId);
+
+    List<Member> findAllAuthId();
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/repository/impl/MemberRepositoryImpl.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/repository/impl/MemberRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static com.ittory.domain.member.domain.QMember.member;
@@ -31,5 +32,13 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .fetchOne();
 
         return Optional.ofNullable(content);
+    }
+
+    @Override
+    public List<Member> findAllAuthId() {
+        return jpaQueryFactory.selectFrom(member)
+                .where(member.loginId.isNotNull())
+                .orderBy(member.id.asc())
+                .fetch();
     }
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/member/service/MemberDomainService.java
@@ -86,4 +86,8 @@ public class MemberDomainService {
     public Member findMemberByLoginId(String loginId) {
         return memberDomainRepository.findByLoginId(loginId).orElseThrow(() -> new MemberNotFoundException(loginId));
     }
+
+    public List<Member> findAllIdMember() {
+        return memberDomainRepository.findAllAuthId();
+    }
 }


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-297 -> develop

### :memo:변경 사항
- 테스트 계정 목록을 조회하는 기능 추가.
- Dev 레벨에서만 사용 가능.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
== API ==
<img width="755" alt="스크린샷 2025-05-02 오후 2 42 50" src="https://github.com/user-attachments/assets/12bc339a-f53c-43fc-abcc-cafdb70eb62a" />


== Socket ==
<img width="789" alt="스크린샷 2025-05-02 오후 2 43 11" src="https://github.com/user-attachments/assets/13ac9264-a522-44ce-9ed8-b24a759596a3" />

