### PR TITLE
RL1M-311 feat: 편지 퇴장 시 Response 수정

### DIFF
--- a/ittory-domain/src/main/java/com/ittory/domain/letter/repository/ElementRepository.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/repository/ElementRepository.java
@@ -6,7 +6,5 @@ import com.ittory.domain.participant.domain.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ElementRepository extends JpaRepository<Element, Long>, ElementRepositoryCustom {
-    Integer countByParticipant(Participant participant);
-
     void deleteAllByLetterId(Long letterId);
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/letter/repository/impl/ElementRepositoryCustom.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/repository/impl/ElementRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.ittory.domain.letter.repository.impl;
 
 import com.ittory.domain.letter.domain.Element;
+import com.ittory.domain.participant.domain.Participant;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -15,4 +16,6 @@ public interface ElementRepositoryCustom {
     Element findByLetterIdAndSequenceWithImage(Long elementId, Integer sequence);
 
     List<Element> findAllByLetterId(Long letterId);
+
+    Integer countNotNullByParticipant(Participant participant);
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/letter/repository/impl/ElementRepositoryImpl.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/repository/impl/ElementRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.ittory.domain.letter.repository.impl;
 
 import com.ittory.domain.letter.domain.Element;
+import com.ittory.domain.participant.domain.Participant;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -66,5 +67,13 @@ public class ElementRepositoryImpl implements ElementRepositoryCustom {
                 .leftJoin(element.elementImage, elementImage).fetchJoin()
                 .where(element.letter.id.eq(letterId))
                 .fetch();
+    }
+
+    @Override
+    public Integer countNotNullByParticipant(Participant participant) {
+        return jpaQueryFactory.selectFrom(element)
+                .where(element.participant.eq(participant)
+                        .and(element.content.isNotNull())
+                ).fetch().size();
     }
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/letter/service/ElementDomainService.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/service/ElementDomainService.java
@@ -30,7 +30,7 @@ public class ElementDomainService {
 
     @Transactional(readOnly = true)
     public Integer countByParticipant(Participant participant) {
-        return elementRepository.countByParticipant(participant);
+        return elementRepository.countNotNullByParticipant(participant);
     }
 
     @Transactional(readOnly = true)

--- a/ittory-socket/src/main/java/com/ittory/socket/dto/ExitResponse.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/dto/ExitResponse.java
@@ -4,6 +4,8 @@ import com.ittory.domain.participant.domain.Participant;
 import com.ittory.socket.enums.ConnectAction;
 import lombok.*;
 
+import java.util.List;
+
 import static com.ittory.socket.enums.ConnectAction.EXIT;
 
 @Getter
@@ -12,17 +14,17 @@ import static com.ittory.socket.enums.ConnectAction.EXIT;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ExitResponse {
 
-    private Long participantId;
-    private String nickname;
-    private ConnectAction action;
+    private ConnectAction actionType;
+    private Long exitMemberId;
     private Boolean isManager;
+    private List<ParticipantProfile> nowParticipants;
 
-    public static ExitResponse from(Participant participant, Boolean isManager) {
+    public static ExitResponse from(Participant participant, Boolean isManager, List<ParticipantProfile> nowParticipants) {
         return ExitResponse.builder()
-                .participantId(participant.getId())
-                .nickname(participant.getNickname())
-                .action(EXIT)
+                .actionType(EXIT)
+                .exitMemberId(participant.getMember().getId())
                 .isManager(isManager)
+                .nowParticipants(nowParticipants)
                 .build();
     }
 

--- a/ittory-socket/src/main/java/com/ittory/socket/service/LetterActionService.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/service/LetterActionService.java
@@ -48,7 +48,11 @@ public class LetterActionService {
         Participant nowParticipant = participantDomainService.findParticipant(letterId, memberId);
         changeParticipantOrder(letterId, nowParticipant);
         changeParticipantStatus(nowParticipant);
-        return ExitResponse.from(nowParticipant, Objects.equals(manager.getId(), nowParticipant.getId()));
+
+        List<ParticipantProfile> nowParticipants = participantDomainService.findAllCurrentParticipantsOrderedBySequence(letterId, true).stream()
+                .map(ParticipantProfile::from)
+                .toList();
+        return ExitResponse.from(nowParticipant, Objects.equals(manager.getId(), nowParticipant.getId()), nowParticipants);
     }
 
     private void changeParticipantStatus(Participant participant) {


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-311 -> feature/RL1M-305

### :memo:변경 사항
- 편지 퇴장 시 Response 수정.
- 퇴장 시 EXITED와 GUEST를 판단하는 기준 수정. element의 participant만 count -> element의 participant and content not null을 count.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
== API ==
<img width="732" alt="스크린샷 2025-05-06 오후 1 54 45" src="https://github.com/user-attachments/assets/9e2f867e-9efa-4dd0-9a60-37daea4e4134" />

== Socket ==
<img width="774" alt="스크린샷 2025-05-06 오후 1 55 03" src="https://github.com/user-attachments/assets/13b9423c-a5bb-4bda-a912-d9daeb0d1ba4" />
