### PR TITLE
RL1M-306 feat: 현재 편지의 요소를 조회하는 기능

### DIFF
--- a/ittory-api/src/main/java/com/ittory/api/letter/controller/ElementController.java
+++ b/ittory-api/src/main/java/com/ittory/api/letter/controller/ElementController.java
@@ -1,14 +1,12 @@
 package com.ittory.api.letter.controller;
 
 import com.ittory.api.letter.dto.ElementImageResponse;
+import com.ittory.api.letter.dto.AllElementsResponse;
 import com.ittory.api.letter.service.ElementService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/element")
@@ -22,6 +20,16 @@ public class ElementController {
     public ResponseEntity<ElementImageResponse> getElementImage(@RequestParam Long letterId,
                                                                 @RequestParam Integer sequence) {
         ElementImageResponse response = elementService.getElementImage(letterId, sequence);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @Operation(summary = "편지의 현재 요소 현황 조회", description = "(Authenticated) \n" +
+            "1. startedAt, memberId, nickname, content : null -> 작성 전 Element \n" +
+            "2. content : null -> 작성 중인 Element \n" +
+            "3. 모두 채워졌을 경우 -> 작성 완료된 Element")
+    @GetMapping("/current/{letterId}")
+    public ResponseEntity<AllElementsResponse> getCurrentElements(@PathVariable Long letterId) {
+        AllElementsResponse response = elementService.getCurrentElements(letterId);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/ittory-api/src/main/java/com/ittory/api/letter/dto/AllElementsResponse.java
+++ b/ittory-api/src/main/java/com/ittory/api/letter/dto/AllElementsResponse.java
@@ -1,0 +1,21 @@
+package com.ittory.api.letter.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AllElementsResponse {
+
+    List<ElementSimpleResponse> elements;
+
+    public static AllElementsResponse from(List<ElementSimpleResponse> elements) {
+        return AllElementsResponse.builder()
+                .elements(elements)
+                .build();
+    }
+
+}

--- a/ittory-api/src/main/java/com/ittory/api/letter/dto/ElementSimpleResponse.java
+++ b/ittory-api/src/main/java/com/ittory/api/letter/dto/ElementSimpleResponse.java
@@ -3,6 +3,8 @@ package com.ittory.api.letter.dto;
 import com.ittory.domain.letter.domain.Element;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -10,19 +12,22 @@ import lombok.*;
 public class ElementSimpleResponse {
 
     private Long elementId;
-    private String nickname;
     private String imageUrl;
     private String content;
-    private Integer sequence;
+    private LocalDateTime startedAt;
+    private Long memberId;
+    private String nickname;
 
     public static ElementSimpleResponse from(Element element) {
+        Long memberId = element.getParticipant() != null ? element.getParticipant().getMember().getId() : null;
         String nickname = element.getParticipant() != null ? element.getParticipant().getNickname() : null;
         return ElementSimpleResponse.builder()
                 .elementId(element.getId())
-                .nickname(nickname)
                 .imageUrl(element.getElementImage().getUrl())
                 .content(element.getContent())
-                .sequence(element.getSequence())
+                .startedAt(element.getStartTime())
+                .memberId(memberId)
+                .nickname(nickname)
                 .build();
     }
 

--- a/ittory-api/src/main/java/com/ittory/api/letter/service/ElementService.java
+++ b/ittory-api/src/main/java/com/ittory/api/letter/service/ElementService.java
@@ -43,4 +43,12 @@ public class ElementService {
                 element.getElementImage().getUrl(), request.getContent(), element.getSequence());
     }
 
+    @Transactional(readOnly = true)
+    public AllElementsResponse getCurrentElements(Long letterId) {
+        List<ElementSimpleResponse> content = elementDomainService.findAllByLetterId(letterId).stream()
+                .map(ElementSimpleResponse::from)
+                .toList();
+
+        return AllElementsResponse.from(content);
+    }
 }


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-306 -> feature/RL1M-305

### :memo:변경 사항
- 현재 편지의 요소를 조회하는 기능 추가.
- Response의 필드를 기준으로 진행 기준 구분.
   1. startedAt, memberId, nickname, content : null -> 작성 전 Element.
   2. content : null -> 작성 중인 Element.
   3. 모두 채워졌을 경우 -> 작성 완료된 Element.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
== API ==
<img width="753" alt="스크린샷 2025-05-07 오후 6 30 45" src="https://github.com/user-attachments/assets/e213d13a-2308-47ef-9b6e-6d69acdd7136" />


== Socket ==
<img width="782" alt="스크린샷 2025-05-07 오후 6 31 17" src="https://github.com/user-attachments/assets/07aa6f8d-2dd6-45f9-a254-f739c17ccb3e" />
