### PR TITLE
RL1M-333 feat : 대기실에서 소켓 연결 해제 시 퇴장

### DIFF
--- a/ittory-socket/src/main/java/com/ittory/socket/config/handler/WebSocketSessionDisconnectHandler.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/config/handler/WebSocketSessionDisconnectHandler.java
@@ -1,0 +1,76 @@
+package com.ittory.socket.config.handler;
+
+import java.util.Map;
+import java.util.concurrent.*;
+
+import com.ittory.domain.participant.domain.Participant;
+import com.ittory.domain.participant.service.ParticipantDomainService;
+import com.ittory.socket.dto.ExitResponse;
+import com.ittory.socket.service.LetterActionService;
+import com.ittory.socket.service.ParticipantSessionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class WebSocketSessionDisconnectHandler {
+    private final ParticipantSessionService participantSessionService;
+    private final ParticipantDomainService participantDomainService;
+    private final LetterActionService letterActionService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private final Map<String, ScheduledFuture<?>> futureMap = new ConcurrentHashMap<>();
+
+    private static final int EXIT_WAIT_TIME = 5;
+
+    public void handleDisconnect(String sessionId) {
+        Boolean isExist = participantSessionService.existParticipantBySessionId(sessionId);
+        log.warn("SessionId={} isExist={}", sessionId, isExist);
+        if (isExist) {
+            try {
+                ScheduledFuture<?> future = scheduler.schedule(() -> {
+                    // 퇴장 처리
+                    Participant participant = participantSessionService.exitParticipantBySession(sessionId);
+                    futureMap.remove(sessionId);
+                    letterActionService.exitFromLetter(participant.getMember().getId(), participant.getLetter().getId(), sessionId);
+
+                    // 메세지 전달
+                    Participant manager = participantDomainService.findManagerByLetterId(participant.getLetter().getId());
+                    String destination = "/topic/letter/" + participant.getLetter().getId();
+                    log.info("Bye {}", sessionId);
+                    messagingTemplate.convertAndSend(destination, ExitResponse.from(participant, manager.getId().equals(participant.getId())));
+
+                }, EXIT_WAIT_TIME, TimeUnit.SECONDS);
+                futureMap.put(sessionId, future);
+            } catch (Exception e) {
+                log.error("Error scheduling exit for sessionId={}: {}", sessionId, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     *
+     * 1. 퇴장 예약 취소
+     * 2. SessionId 변경
+     */
+    public void handleReconnect(String sessionId, Long memberId) {
+        // 퇴장 예약 취소
+        String oldSessionId = participantSessionService.findSessionIdByMemberId(memberId);
+        ScheduledFuture<?> future = null;
+        if (oldSessionId != null) {
+            future = futureMap.remove(oldSessionId);
+        }
+        if (future != null) {
+            future.cancel(true);
+            log.info("Cancelled scheduled exit for sessionId={}", sessionId);
+        }
+
+        // SessionId 변경
+        participantSessionService.changeSessionIdByMemberId(sessionId, memberId);
+    }
+
+}

--- a/ittory-socket/src/main/java/com/ittory/socket/controller/LetterConnectController.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/controller/LetterConnectController.java
@@ -33,7 +33,7 @@ public class LetterConnectController {
     public void exitMember(@CurrentMemberId Long memberId, @DestinationVariable Long letterId, SimpMessageHeaderAccessor headerAccessor) {
         String sessionId = headerAccessor.getSessionId();
         log.info("member {}, exit from letter {} with SessionId: {}", memberId, letterId, sessionId);
-        ExitResponse response = letterActionService.exitFromLetter(memberId, letterId);
+        ExitResponse response = letterActionService.exitFromLetter(memberId, letterId, sessionId);
         String destination = "/topic/letter/" + letterId;
         messagingTemplate.convertAndSend(destination, response);
     }

--- a/ittory-socket/src/main/java/com/ittory/socket/service/LetterActionService.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/service/LetterActionService.java
@@ -5,6 +5,7 @@ import com.ittory.domain.participant.domain.Participant;
 import com.ittory.domain.participant.enums.ParticipantStatus;
 import com.ittory.domain.participant.service.ParticipantDomainService;
 import com.ittory.socket.dto.*;
+import com.ittory.socket.utils.ConnectSessionStorage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,8 @@ public class LetterActionService {
     private final ParticipantDomainService participantDomainService;
     private final ElementDomainService elementDomainService;
 
+    private final ConnectSessionStorage connectSessionStorage;
+
     @Transactional
     public EnterResponse enterToLetter(Long memberId, Long letterId, String sessionId) {
         Participant participant = participantDomainService.findParticipant(letterId, memberId);
@@ -31,15 +34,22 @@ public class LetterActionService {
                 .map(ParticipantProfile::from)
                 .toList();
 
+        connectSessionStorage.saveSessionId(sessionId, participant);
+
         return EnterResponse.from(participant, participants);
     }
 
     @Transactional
-    public ExitResponse exitFromLetter(Long memberId, Long letterId) {
+    public ExitResponse exitFromLetter(Long memberId, Long letterId, String sessionId) {
         Participant manager = participantDomainService.findManagerByLetterId(letterId);
         Participant nowParticipant = participantDomainService.findParticipant(letterId, memberId);
         changeParticipantOrder(letterId, nowParticipant);
         changeParticipantStatus(nowParticipant);
+
+        if (sessionId != null) {
+            connectSessionStorage.removeBySessionId(sessionId);
+        }
+
         return ExitResponse.from(nowParticipant, Objects.equals(manager.getId(), nowParticipant.getId()));
     }
 

--- a/ittory-socket/src/main/java/com/ittory/socket/service/LetterProcessService.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/service/LetterProcessService.java
@@ -25,6 +25,7 @@ public class LetterProcessService {
     private final LetterDomainService letterDomainService;
     private final ElementDomainService elementDomainService;
     private final LetterBoxDomainService letterBoxDomainService;
+    private final ParticipantSessionService participantSessionService;
 
     private final WriteTimeManager writeTimeManager;
 
@@ -38,6 +39,10 @@ public class LetterProcessService {
         Participant participant = participantDomainService.findParticipantBySequence(letterId, 1);
         LocalDateTime now = LocalDateTime.now();
         elementDomainService.updateStartTimeAndWriter(letterId, 1, participant, now);
+
+        // ConnectSession 삭제
+        List<Participant> allParticipants = participantDomainService.findAllParticipants(letterId);
+        participantSessionService.removeAllSessions(allParticipants);
 
         // 타이머 설정
         writeTimeManager.registerWriteTimer(letterId, now, participant.getId(), 14);

--- a/ittory-socket/src/main/java/com/ittory/socket/service/ParticipantSessionService.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/service/ParticipantSessionService.java
@@ -1,0 +1,46 @@
+package com.ittory.socket.service;
+
+import com.ittory.domain.participant.domain.Participant;
+import com.ittory.socket.utils.ConnectSessionStorage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ParticipantSessionService {
+
+    private final ConnectSessionStorage connectSessionStorage;
+
+    public Boolean existParticipantBySessionId(String sessionId) {
+        return connectSessionStorage.findMemberIdBySessionId(sessionId) != null;
+    }
+
+    public Participant exitParticipantBySession(String sessionId) {
+        Participant sessionParticipant = connectSessionStorage.findParticipantBySessionId(sessionId);
+        connectSessionStorage.removeBySessionId(sessionId);
+        return sessionParticipant;
+    }
+
+    public String findSessionIdByMemberId(Long memberId) {
+        return connectSessionStorage.findSessionIdByMemberId(memberId);
+    }
+
+    public void changeSessionIdByMemberId(String sessionId, Long memberId) {
+        Participant nowParticipant = connectSessionStorage.findParticipantByMemberId(memberId);
+        connectSessionStorage.removeByMemberId(nowParticipant.getMember().getId());
+        connectSessionStorage.saveSessionId(sessionId, nowParticipant);
+    }
+
+    public Participant findParticipantByMemberId(Long memberId) {
+        return connectSessionStorage.findParticipantByMemberId(memberId);
+    }
+
+    public void removeAllSessions(List<Participant> allParticipants) {
+        for (Participant participant : allParticipants) {
+            connectSessionStorage.removeByMemberId(participant.getMember().getId());
+        }
+    }
+
+}

--- a/ittory-socket/src/main/java/com/ittory/socket/utils/ConnectSessionStorage.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/utils/ConnectSessionStorage.java
@@ -1,0 +1,70 @@
+package com.ittory.socket.utils;
+
+import com.ittory.domain.participant.domain.Participant;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class ConnectSessionStorage {
+
+    private final Map<String, Participant> SESSIONID_KEY_MAP = new ConcurrentHashMap<>();
+    private final Map<Long, String> MEMBERID_KEY_MAP = new ConcurrentHashMap<>();
+
+
+    public void saveSessionId(String sessionId, Participant participant) {
+        SESSIONID_KEY_MAP.put(sessionId, participant);
+        MEMBERID_KEY_MAP.put(participant.getMember().getId(), sessionId);
+    }
+
+    public Participant findParticipantByMemberId(Long memberId) {
+        if (!MEMBERID_KEY_MAP.containsKey(memberId)) {
+            return null;
+        }
+        String sessionId = MEMBERID_KEY_MAP.get(memberId);
+
+        if (!SESSIONID_KEY_MAP.containsKey(sessionId)) {
+            return null;
+        }
+        return SESSIONID_KEY_MAP.get(sessionId);
+    }
+
+    public Participant findParticipantBySessionId(String sessionId) {
+        if (!SESSIONID_KEY_MAP.containsKey(sessionId)) {
+            return null;
+        }
+        return SESSIONID_KEY_MAP.get(sessionId);
+    }
+
+    public String findSessionIdByMemberId(Long memberId) {
+        if (!MEMBERID_KEY_MAP.containsKey(memberId)) {
+            return null;
+        }
+        return MEMBERID_KEY_MAP.get(memberId);
+    }
+
+    public Participant findMemberIdBySessionId(String sessionId) {
+        if (!SESSIONID_KEY_MAP.containsKey(sessionId)) {
+            return null;
+        }
+        return SESSIONID_KEY_MAP.get(sessionId);
+    }
+
+    public void removeBySessionId(String sessionId) {
+        if (SESSIONID_KEY_MAP.containsKey(sessionId)) {
+            Participant removedParticipant = SESSIONID_KEY_MAP.remove(sessionId);
+            MEMBERID_KEY_MAP.remove(removedParticipant.getMember().getId());
+        }
+    }
+
+    public void removeByMemberId(Long memberId) {
+        if (MEMBERID_KEY_MAP.containsKey(memberId)) {
+            String removedSessionId = MEMBERID_KEY_MAP.remove(memberId);
+            SESSIONID_KEY_MAP.remove(removedSessionId);
+        }
+    }
+
+}

--- a/ittory-socket/src/main/java/com/ittory/socket/utils/WriteTimeManager.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/utils/WriteTimeManager.java
@@ -70,7 +70,7 @@ public class WriteTimeManager {
         if (participant.getTimeoutCount() >= TIMEOUT_EJECTION_COUNT) {
             // 퇴장 로직
             Long memberId = participant.getMember().getId();
-            letterActionService.exitFromLetter(memberId, letterId);
+            letterActionService.exitFromLetter(memberId, letterId, null);
             log.info("Member {} TIMEOUT Exit from Letter {}", memberId, letterId);
 
             // 퇴장 메세지
@@ -84,7 +84,7 @@ public class WriteTimeManager {
 
     private void proceedToNextParticipant(Long letterId, Participant participant, boolean isExited) {
         Participant nextParticipant = participantService.findNextParticipant(letterId, participant, isExited);
-        log.warn("Next Participant Id: {}, nickname: {}", nextParticipant.getId(), nextParticipant.getNickname());
+
         if (nextParticipant != null) {
             LocalDateTime nowTime = LocalDateTime.now();
             elementDomainService.changeProcessDataByLetterId(letterId, nowTime, nextParticipant);


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-333 -> develop

### :memo:변경 사항
- 대기실에서 소켓 연결 해제 시 5초 뒤 퇴장 로직 실행.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
= API =
<img width="790" alt="스크린샷 2025-05-24 오후 8 05 22" src="https://github.com/user-attachments/assets/bff71bfa-e55b-4e06-9e0d-5667eb754601" />

= Sokcet =
<img width="776" alt="스크린샷 2025-05-24 오후 8 05 49" src="https://github.com/user-attachments/assets/50948895-1f61-4366-b6ab-c9c76b3c3e95" />
