### PR TITLE
Feature/RL1M-363

### DIFF
--- a/ittory-api/src/main/java/com/ittory/api/letter/dto/LetterDetailResponse.java
+++ b/ittory-api/src/main/java/com/ittory/api/letter/dto/LetterDetailResponse.java
@@ -23,6 +23,7 @@ public class LetterDetailResponse {
     private LocalDateTime deliveryDate;
     private String title;
     private String coverPhotoUrl;
+    private LocalDateTime finishedAt;
     private List<String> participantNames;
     private List<LetterElementResponse> elements;
 
@@ -35,6 +36,7 @@ public class LetterDetailResponse {
                 .deliveryDate(letter.getDeliveryDate())
                 .title(letter.getTitle())
                 .coverPhotoUrl(letter.getCoverPhotoUrl())
+                .finishedAt(letter.getFinishedAt())
                 .participantNames(participantNames)
                 .elements(elements.stream()
                         .map(LetterElementResponse::from)

--- a/ittory-domain/src/main/java/com/ittory/domain/letter/domain/Letter.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/letter/domain/Letter.java
@@ -46,6 +46,9 @@ public class Letter extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private LetterStatus letterStatus;
 
+    private LocalDateTime finishedAt;
+
+
     public static Letter create(CoverType coverType, Font font, String receiverName, LocalDateTime deliveryDate,
                                 String title, String coverPhotoUrl, Integer repeatCount) {
         return Letter.builder()
@@ -66,6 +69,9 @@ public class Letter extends BaseEntity {
 
     public void changeStatus(LetterStatus letterStatus) {
         this.letterStatus = letterStatus;
+    }
+    public void changeFinishedAt(LocalDateTime finishedAt) {
+        this.finishedAt = finishedAt;
     }
 
 }

--- a/ittory-domain/src/main/java/com/ittory/domain/participant/exception/ParticipantException.java
+++ b/ittory-domain/src/main/java/com/ittory/domain/participant/exception/ParticipantException.java
@@ -45,7 +45,7 @@ public class ParticipantException extends GlobalException {
 
     public static class DuplicateNicknameException extends ParticipantException {
         public DuplicateNicknameException(String nickname) {
-            super(DUPLICATE_PARTICIPANT_ERROR.getStatus(),
+            super(DUPLICATE_NICKNAME_ERROR.getStatus(),
                     new ErrorInfo<>(DUPLICATE_NICKNAME_ERROR.getCode(), DUPLICATE_NICKNAME_ERROR.getMessage(), nickname));
         }
     }

--- a/ittory-socket/src/main/java/com/ittory/socket/service/LetterProcessService.java
+++ b/ittory-socket/src/main/java/com/ittory/socket/service/LetterProcessService.java
@@ -52,6 +52,7 @@ public class LetterProcessService {
         return StartResponse.from(letterId);
     }
 
+    @Transactional
     public void finishLetter(Long letterId) {
         // 타이머 제거
         writeTimeManager.removeWriteTimer(letterId);
@@ -64,5 +65,8 @@ public class LetterProcessService {
         Letter letter = letterDomainService.findLetter(letterId);
         List<Participant> participants = participantDomainService.findAllParticipants(letterId);
         letterBoxDomainService.saveAllInParticipationLetterBox(participants, letter);
+
+        // 종료 시간 저장
+        letter.changeFinishedAt(LocalDateTime.now());
     }
 }


### PR DESCRIPTION
### :pushpin:PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### :sparkles:반영 브랜치
- feature/RL1M-363 -> develop

### :memo:변경 사항
- 편지에 작성 종료 시점 저장하는 기능 추가.
- Exception에서 Enum을 잘못 참조하고 있던 현상 수정.

### :heavy_plus_sign:추가 메모 (없다면 X)
X

### :bug:테스트 결과 (테스트 결과가 있다면 넣어주세요. 없다면 X)
== API ==
<img width="725" alt="스크린샷 2025-06-05 오전 10 45 13" src="https://github.com/user-attachments/assets/308be71c-7c7e-4f2d-81a3-fa4e8f3f978b" />

== Socket ==
<img width="760" alt="스크린샷 2025-06-05 오전 10 45 36" src="https://github.com/user-attachments/assets/6ad2a889-c92d-426d-ae9c-f27520c1a83c" />
